### PR TITLE
Refine research visuals and visit counter

### DIFF
--- a/_includes/analytics-providers/goatcounter.html
+++ b/_includes/analytics-providers/goatcounter.html
@@ -11,10 +11,8 @@
       analytics.src = "https://gc.zgo.at/count.js";
       analytics.dataset.goatcounter = endpoint + "/count";
 {% if site.page_views.enabled and site.page_views.provider == "goatcounter" %}
-      analytics.addEventListener("load", function () {
-        var display = document.getElementById("goatcounter_site_views");
-        if (!display) return;
-
+      var display = document.getElementById("goatcounter_site_views");
+      if (display) {
         var request = new XMLHttpRequest();
         request.addEventListener("load", function () {
           if (request.status < 200 || request.status >= 300) return;
@@ -27,7 +25,7 @@
         });
         request.open("GET", endpoint + "/counter/TOTAL.json");
         request.send();
-      });
+      }
 {% endif %}
       document.body.appendChild(analytics);
     }());

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -7,7 +7,7 @@
 {% when "google-universal" %}
   {% include /analytics-providers/google-universal.html %}
 {% when "goatcounter" %}
-  {% include /analytics-providers/goatcounter.html %}
+  {% comment %}Loaded from the footer after the public counter placeholder.{% endcomment %}
 {% when "custom" %}
   {% include /analytics-providers/custom.html %}
 {% endcase %}

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -13,3 +13,7 @@
     <a href="mailto:liuh@ust.hk">Email</a>
   </nav>
 </div>
+
+{% if site.analytics.provider == "goatcounter" and page.analytics != false %}
+  {% include /analytics-providers/goatcounter.html %}
+{% endif %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -94,11 +94,15 @@ redirect_from:
   <div class="home-join">
     <article>
       <h3>Postdoc and PhD students</h3>
-      <p>Postdoctoral / Research Associate positions are available. Prospective Ph.D. and visiting students whose interests align with our research are also welcome. Please email your CV and representative work to <a href="mailto:liuh@ust.hk">liuh@ust.hk</a>.</p>
+      <p>Postdoctoral / Research Associate positions are available. Prospective Ph.D. students whose interests align with our research are also welcome. Please email your CV and representative work to <a href="mailto:liuh@ust.hk">liuh@ust.hk</a>.</p>
     </article>
     <article>
       <h3>RBM students</h3>
       <p>Please apply directly through the <a href="https://pgoas.hkust-gz.edu.cn/">HKUST(GZ) Online Admission System</a>. After receiving an offer, you are welcome to contact me to discuss research fit; joining the group as an RA before making a final decision is encouraged. Please read the <a href="{{ site.baseurl }}/files/MPhil_Guideline.pdf">Guidelines &amp; Expectations</a>.</p>
+    </article>
+    <article>
+      <h3>RAs, interns, and visiting students</h3>
+      <p>We welcome applications year-round from students who can commit for at least six months. We provide a stipend, computing resources, and close research mentorship. Please email your CV, availability, and a brief description of your research interests to <a href="mailto:liuh@ust.hk">liuh@ust.hk</a>.</p>
     </article>
   </div>
 </section>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -14,9 +14,9 @@ author_profile: false
 <figure class="research-framework">
   <picture>
     <source media="(max-width: 560px)" srcset="{{ site.baseurl }}/images/research/research-overview-mobile.svg">
-    <img src="{{ site.baseurl }}/images/research/research-overview.svg" alt="Research framework connecting models of dynamic worlds, grounded physical agents, and agentic data scientists in a continuous feedback loop.">
+    <img src="{{ site.baseurl }}/images/research/research-overview.svg" alt="Research framework connecting models of dynamic worlds, grounded physical agents, and agentic data scientists around agentic intelligence across digital-physical space.">
   </picture>
-  <figcaption>The three themes form a coupled loop: models support grounded action, interaction produces observations and consequences, and data-science agents turn evidence into discovery, reusable workflows, and improved systems.</figcaption>
+  <figcaption>The three themes are mutually reinforcing: data-science agents build and interrogate world models, models guide physical action, and interaction returns evidence that improves both models and workflows.</figcaption>
 </figure>
 
 <section class="research-perspectives" aria-labelledby="research-perspectives-heading">

--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -499,7 +499,7 @@
 
 .home-join {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 2rem;
 }
 
@@ -1289,7 +1289,8 @@
   }
 
   .home-join {
-    gap: 1.25rem;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
   }
 
   .research-index {

--- a/images/research/agentic-data-scientists.svg
+++ b/images/research/agentic-data-scientists.svg
@@ -1,21 +1,30 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 180" role="img" aria-labelledby="title">
-  <title id="title">Agentic data science workflow</title>
+  <title id="title">Agentic data science workflow from data to evaluated results</title>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#557a68"/>
+    </marker>
+  </defs>
   <rect x="1" y="1" width="298" height="178" rx="18" fill="#f4f6f1" stroke="#dfe2da"/>
+
   <g fill="none" stroke="#557a68" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
-    <ellipse cx="57" cy="51" rx="29" ry="11" fill="#e3ece6"/>
-    <path d="M 28 51 V 109 C 28 123 86 123 86 109 V 51"/>
-    <path d="M 28 78 C 28 92 86 92 86 78 M 28 101 C 28 115 86 115 86 101"/>
-    <path d="M 88 83 H 120"/>
-    <circle cx="141" cy="83" r="19" fill="#ffffff"/>
-    <path d="M 160 83 H 190"/>
-    <rect x="193" y="42" width="78" height="82" rx="10" fill="#ffffff"/>
-    <path d="M 208 102 L 223 82 L 236 91 L 256 63"/>
-    <path d="M 207 111 H 258" stroke="#b4c3ba" stroke-width="2"/>
-    <path d="M 134 75 L 141 68 L 148 75 M 134 91 L 141 98 L 148 91"/>
+    <ellipse cx="48" cy="51" rx="27" ry="10" fill="#e3ece6"/>
+    <path d="M 21 51 V 111 C 21 124 75 124 75 111 V 51"/>
+    <path d="M 21 79 C 21 92 75 92 75 79 M 21 103 C 21 116 75 116 75 103"/>
+
+    <path d="M 77 83 H 104" marker-end="url(#arrow)"/>
+    <circle cx="133" cy="83" r="27" fill="#ffffff"/>
+    <path d="M 124 74 L 133 65 L 142 74 M 124 92 L 133 101 L 142 92"/>
+    <circle cx="133" cy="83" r="4" fill="#557a68"/>
+    <path d="M 133 49 V 56 M 133 110 V 117 M 99 83 H 106 M 160 83 H 167"/>
+
+    <path d="M 161 83 H 190" marker-end="url(#arrow)"/>
+    <rect x="195" y="40" width="79" height="85" rx="10" fill="#ffffff"/>
+    <path d="M 208 106 L 222 87 L 235 95 L 258 63"/>
+    <circle cx="258" cy="63" r="4" fill="#e3ece6"/>
+    <path d="M 208 113 H 261" stroke="#b4c3ba" stroke-width="2"/>
+
+    <path d="M 244 136 C 204 159 94 159 52 134" stroke-width="2.3" stroke-dasharray="6 6" marker-end="url(#arrow)"/>
   </g>
-  <g fill="#557a68">
-    <circle cx="112" cy="83" r="4"/>
-    <circle cx="178" cy="83" r="4"/>
-    <path d="M 235 29 L 239 38 L 248 42 L 239 46 L 235 55 L 231 46 L 222 42 L 231 38 Z"/>
-  </g>
+  <path d="M 236 24 L 240 34 L 250 38 L 240 42 L 236 52 L 232 42 L 222 38 L 232 34 Z" fill="#557a68"/>
 </svg>

--- a/images/research/grounded-physical-agents.svg
+++ b/images/research/grounded-physical-agents.svg
@@ -1,24 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 180" role="img" aria-labelledby="title">
-  <title id="title">Grounded agents coordinating in a physical environment</title>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 180" role="img" aria-labelledby="title desc">
+  <title id="title">A grounded agent acting in and learning from the physical world</title>
+  <desc id="desc">A controller sends actions to a robot interacting with an object, while observations and consequences return as feedback.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#557a68"/>
+    </marker>
+  </defs>
   <rect x="1" y="1" width="298" height="178" rx="18" fill="#f4f6f1" stroke="#dfe2da"/>
-  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M 20 58 H 280 M 20 122 H 280 M 80 18 V 162 M 220 18 V 162" stroke="#d4ddd7" stroke-width="2"/>
-    <path d="M 150 18 V 162 M 20 90 H 280" stroke="#c2cec6" stroke-width="2" stroke-dasharray="7 8"/>
-    <g stroke="#557a68" stroke-width="3">
-      <circle cx="80" cy="58" r="18" fill="#e3ece6"/>
-      <circle cx="220" cy="58" r="18" fill="#ffffff"/>
-      <circle cx="150" cy="122" r="18" fill="#ffffff"/>
-      <path d="M 99 58 H 198"/>
-      <path d="M 210 76 L 163 107"/>
-      <path d="M 137 108 L 93 73"/>
-    </g>
-  </g>
-  <g fill="#557a68">
-    <path d="M 199 53 L 210 58 L 199 63 Z"/>
-    <path d="M 167 101 L 163 112 L 155 104 Z"/>
-    <path d="M 99 72 L 89 68 L 92 79 Z"/>
-    <circle cx="80" cy="58" r="5"/>
-    <circle cx="220" cy="58" r="5"/>
-    <circle cx="150" cy="122" r="5"/>
+
+  <g fill="none" stroke="#557a68" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Agent/controller. -->
+    <rect x="28" y="59" width="66" height="66" rx="14" fill="#ffffff"/>
+    <circle cx="61" cy="92" r="13" fill="#e3ece6"/>
+    <circle cx="61" cy="92" r="4" fill="#557a68"/>
+    <path d="M 61 44 V 59 M 61 125 V 140 M 13 92 H 28 M 94 92 H 109"/>
+    <path d="M 43 51 V 59 M 79 51 V 59 M 43 125 V 133 M 79 125 V 133" stroke-width="2"/>
+
+    <!-- Action reaches into the physical world. -->
+    <path d="M 105 58 C 142 27 210 26 242 55" marker-end="url(#arrow)"/>
+
+    <!-- Articulated body visibly contacts and moves an object. -->
+    <rect x="199" y="137" width="58" height="13" rx="4" fill="#e3ece6"/>
+    <path d="M 228 137 L 228 124 L 194 100 L 222 71"/>
+    <circle cx="228" cy="124" r="7" fill="#ffffff"/>
+    <circle cx="194" cy="100" r="7" fill="#ffffff"/>
+    <circle cx="222" cy="71" r="7" fill="#ffffff"/>
+    <path d="M 222 71 L 238 61 M 222 71 L 239 83"/>
+    <rect x="244" y="66" width="20" height="20" rx="3" fill="#e3ece6"/>
+    <path d="M 238 76 H 244"/>
+    <path d="M 187 151 H 276" stroke="#b4c3ba" stroke-width="2"/>
+    <path d="M 250 57 L 254 50 L 258 57 M 267 76 L 276 76 M 250 92 L 254 99 L 258 92" stroke="#91aa9c" stroke-width="2"/>
+
+    <!-- Consequences close the action-observation loop. -->
+    <path d="M 250 156 C 206 176 137 171 98 140" stroke="#91aa9c" stroke-width="2.4" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/images/research/models-dynamic-worlds.svg
+++ b/images/research/models-dynamic-worlds.svg
@@ -1,13 +1,40 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 180" role="img" aria-labelledby="title">
-  <title id="title">A model learning changing world dynamics over time</title>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 180" role="img" aria-labelledby="title desc">
+  <title id="title">A world model learning latent dynamics and imagining future states</title>
+  <desc id="desc">An observed relational world is encoded into a latent dynamics model and rolled forward into a predicted future world.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#557a68"/>
+    </marker>
+  </defs>
   <rect x="1" y="1" width="298" height="178" rx="18" fill="#f4f6f1" stroke="#dfe2da"/>
-  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M 27 136 H 273 M 41 28 V 148" stroke="#c4cfc8" stroke-width="2"/>
-    <path d="M 41 116 C 63 113 70 69 94 71 C 118 74 115 110 140 106 C 165 101 173 45 202 50 C 227 54 231 92 262 70" stroke="#557a68" stroke-width="4"/>
-    <path d="M 41 125 C 70 121 78 99 104 101 C 132 104 138 125 165 119 C 194 113 208 77 262 84" stroke="#91aa9c" stroke-width="3" stroke-dasharray="6 7"/>
-    <path d="M 84 35 V 136 M 150 35 V 136 M 216 35 V 136" stroke="#d8dfda" stroke-width="1.5"/>
-    <circle cx="94" cy="71" r="6" fill="#f4f6f1" stroke="#557a68" stroke-width="3"/>
-    <circle cx="202" cy="50" r="6" fill="#f4f6f1" stroke="#557a68" stroke-width="3"/>
+
+  <g fill="none" stroke="#557a68" stroke-width="2.7" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Observed world state. -->
+    <rect x="18" y="48" width="70" height="88" rx="11" fill="#e3ece6"/>
+    <path d="M 31 116 L 50 72 L 75 101"/>
+    <circle cx="31" cy="116" r="5" fill="#f4f6f1"/>
+    <circle cx="50" cy="72" r="5" fill="#f4f6f1"/>
+    <circle cx="75" cy="101" r="5" fill="#f4f6f1"/>
+    <path d="M 27 62 H 43" stroke="#91aa9c" stroke-width="2"/>
+
+    <!-- Latent dynamics: a compact internal model of how the world changes. -->
+    <circle cx="150" cy="89" r="43" fill="#ffffff"/>
+    <path d="M 123 95 C 127 65 158 55 174 76 C 190 97 168 123 139 112 Z"/>
+    <path d="M 121 75 C 143 82 160 105 174 119 M 116 101 C 139 96 168 83 183 67" stroke="#91aa9c" stroke-width="2.1"/>
+    <circle cx="132" cy="68" r="5" fill="#e3ece6"/>
+    <circle cx="173" cy="79" r="5" fill="#e3ece6"/>
+    <circle cx="144" cy="115" r="5" fill="#e3ece6"/>
+    <path d="M 150 39 C 180 42 199 65 198 91" stroke="#91aa9c" stroke-width="2.1" marker-end="url(#arrow)"/>
+
+    <!-- Imagined future world. -->
+    <rect x="212" y="48" width="70" height="88" rx="11" fill="#ffffff" stroke-dasharray="6 5"/>
+    <path d="M 225 109 L 249 61 L 274 91"/>
+    <circle cx="225" cy="109" r="5" fill="#f4f6f1"/>
+    <circle cx="249" cy="61" r="5" fill="#f4f6f1"/>
+    <circle cx="274" cy="91" r="5" fill="#f4f6f1"/>
+    <path d="M 257 119 H 273" stroke="#91aa9c" stroke-width="2"/>
+
+    <path d="M 92 89 H 102" marker-end="url(#arrow)"/>
+    <path d="M 198 89 H 208" marker-end="url(#arrow)"/>
   </g>
-  <path d="M 250 42 L 254 51 L 263 55 L 254 59 L 250 68 L 246 59 L 237 55 L 246 51 Z" fill="#557a68"/>
 </svg>

--- a/images/research/research-overview-mobile.svg
+++ b/images/research/research-overview-mobile.svg
@@ -1,18 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 1160" role="img" aria-labelledby="title desc">
   <title id="title">Research framework</title>
-  <desc id="desc">A vertical research loop connects models of dynamic worlds, grounded physical agents, and agentic data scientists.</desc>
+  <desc id="desc">A compact vertical loop connects agentic data scientists, models of dynamic worlds, and grounded physical agents.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#527866"/>
     </marker>
+    <marker id="mini-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="5.5" markerHeight="5.5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#678d7b"/>
+    </marker>
   </defs>
   <rect x="1" y="1" width="638" height="1158" rx="28" fill="#f5f6f1" stroke="#dfe2da"/>
 
-  <rect x="70" y="45" width="500" height="142" rx="28" fill="#e8efea" stroke="#678d7b" stroke-width="2"/>
+  <rect x="70" y="45" width="500" height="150" rx="28" fill="#e8efea" stroke="#678d7b" stroke-width="2"/>
   <g font-family="Arial, Helvetica, sans-serif" text-anchor="middle">
-    <text x="320" y="93" fill="#1d2822" font-size="29" font-weight="700">Agentic intelligence</text>
-    <text x="320" y="128" fill="#1d2822" font-size="23" font-weight="600">across digital &amp; physical worlds</text>
-    <text x="320" y="160" fill="#66736b" font-size="16" font-weight="600">UNDERSTAND · DECIDE · LEARN</text>
+    <text x="320" y="94" fill="#1d2822" font-size="28" font-weight="700">Agentic Intelligence Across</text>
+    <text x="320" y="130" fill="#1d2822" font-size="25" font-weight="600">Digital-Physical Space</text>
+    <g fill="#66736b" font-size="14" font-weight="700">
+      <text x="225" y="164">UNDERSTAND</text>
+      <circle cx="274" cy="159" r="2" fill="#8a958e"/>
+      <text x="320" y="164">DECIDE</text>
+      <circle cx="361" cy="159" r="2" fill="#8a958e"/>
+      <text x="407" y="164">LEARN</text>
+    </g>
   </g>
 
   <g fill="#ffffff" stroke="#cbd6ce">
@@ -21,27 +30,78 @@
     <rect x="60" y="825" width="520" height="190" rx="24"/>
   </g>
 
-  <g font-family="Arial, Helvetica, sans-serif" fill="#202622" text-anchor="middle">
-    <text x="320" y="318" font-size="31" font-weight="700">Models of Dynamic Worlds</text>
-    <text x="320" y="359" font-size="20" fill="#657069">Represent · forecast · adapt</text>
-
-    <text x="320" y="608" font-size="31" font-weight="700">Grounded Physical Agents</text>
-    <text x="320" y="649" font-size="20" fill="#657069">Reason · coordinate · act</text>
-
-    <text x="320" y="898" font-size="31" font-weight="700">Agentic Data Scientists</text>
-    <text x="320" y="939" font-size="20" fill="#657069">Analyze · discover · improve</text>
+  <!-- Agentic data science symbol. -->
+  <g transform="translate(93 292)" fill="none" stroke="#678d7b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <ellipse cx="22" cy="17" rx="20" ry="8" fill="#edf3ef"/>
+    <path d="M 2 17 V 66 C 2 76 42 76 42 66 V 17 M 2 41 C 2 51 42 51 42 41"/>
+    <path d="M 43 44 H 56"/>
+    <circle cx="72" cy="44" r="16" fill="#f9fbf8"/>
+    <path d="M 65 38 L 72 31 L 79 38 M 65 50 L 72 57 L 79 50"/>
+    <path d="M 88 44 H 101"/>
+    <rect x="102" y="14" width="48" height="60" rx="7" fill="#f9fbf8"/>
+    <path d="M 111 60 L 121 47 L 130 53 L 143 33 M 111 65 H 143"/>
   </g>
 
-  <g fill="none" stroke="#527866" stroke-width="3" marker-end="url(#arrow)">
-    <path d="M 320 435 V 520"/>
-    <path d="M 320 725 V 810"/>
-    <path d="M 580 920 C 625 920 625 340 580 340"/>
+  <!-- World model: observations are encoded into latent dynamics and rolled forward. -->
+  <g transform="translate(91 583)" fill="none" stroke="#678d7b" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="0" y="13" width="43" height="65" rx="7" fill="#edf3ef"/>
+    <path d="M 8 61 L 21 31 L 35 48"/>
+    <circle cx="8" cy="61" r="3.5" fill="#678d7b"/><circle cx="21" cy="31" r="3.5" fill="#678d7b"/><circle cx="35" cy="48" r="3.5" fill="#678d7b"/>
+
+    <circle cx="81" cy="45" r="24" fill="#f9fbf8"/>
+    <path d="M 66 49 C 69 31 88 26 96 40 C 103 54 88 65 73 58 Z"/>
+    <path d="M 64 37 C 76 42 87 55 94 62 M 61 51 C 74 48 91 41 101 34" stroke-width="2"/>
+    <circle cx="72" cy="35" r="3" fill="#678d7b"/><circle cx="93" cy="42" r="3" fill="#678d7b"/><circle cx="79" cy="59" r="3" fill="#678d7b"/>
+
+    <rect x="118" y="13" width="43" height="65" rx="7" fill="#f9fbf8" stroke-dasharray="6 5"/>
+    <path d="M 126 56 L 140 25 L 154 44"/>
+    <circle cx="126" cy="56" r="3.5" fill="#678d7b"/><circle cx="140" cy="25" r="3.5" fill="#678d7b"/><circle cx="154" cy="44" r="3.5" fill="#678d7b"/>
+    <path d="M 46 46 H 53 M 109 46 H 115" marker-end="url(#mini-arrow)"/>
   </g>
-  <g fill="#f5f6f1" font-family="Arial, Helvetica, sans-serif" font-size="17" font-weight="600" text-anchor="middle">
-    <rect x="194" y="465" width="252" height="32" rx="16"/>
-    <text x="320" y="487" fill="#526059">representations &amp; forecasts</text>
-    <rect x="193" y="755" width="254" height="32" rx="16"/>
-    <text x="320" y="777" fill="#526059">observations &amp; consequences</text>
+
+  <!-- Physical interaction: an agent acts on the world and learns from feedback. -->
+  <g transform="translate(88 875)" fill="none" stroke="#678d7b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="0" y="27" width="44" height="44" rx="10" fill="#f9fbf8"/>
+    <circle cx="22" cy="49" r="8" fill="#edf3ef"/>
+    <circle cx="22" cy="49" r="3" fill="#678d7b"/>
+    <path d="M 22 17 V 27 M 22 71 V 81 M -10 49 H 0 M 44 49 H 54"/>
+
+    <path d="M 50 23 C 80 3 124 3 150 25" marker-end="url(#mini-arrow)"/>
+    <path d="M 150 78 C 120 97 78 97 50 73" marker-end="url(#mini-arrow)"/>
+
+    <path d="M 124 76 L 124 66 L 103 49 L 123 31"/>
+    <circle cx="124" cy="66" r="5" fill="#ffffff"/>
+    <circle cx="103" cy="49" r="5" fill="#ffffff"/>
+    <circle cx="123" cy="31" r="5" fill="#ffffff"/>
+    <path d="M 123 31 L 136 24 M 123 31 L 137 39"/>
+    <rect x="142" y="27" width="16" height="16" rx="2" fill="#edf3ef"/>
+    <path d="M 133 76 H 172 M 143 49 L 143 55 M 158 49 L 158 55" stroke="#91aa9c" stroke-width="2"/>
+    <path d="M 144 19 L 150 12 L 156 19" stroke="#91aa9c" stroke-width="2"/>
   </g>
-  <text x="610" y="631" transform="rotate(-90 610 631)" fill="#526059" font-family="Arial, Helvetica, sans-serif" font-size="17" font-weight="600" text-anchor="middle">knowledge &amp; reusable workflows</text>
+
+  <g font-family="Arial, Helvetica, sans-serif" fill="#202622">
+    <text x="275" y="313" font-size="29" font-weight="700">Agentic Data</text>
+    <text x="275" y="348" font-size="29" font-weight="700">Scientists</text>
+    <text x="275" y="391" font-size="18" fill="#657069">Analyze · discover · improve</text>
+
+    <text x="275" y="603" font-size="27" font-weight="700">Models of Dynamic</text>
+    <text x="275" y="638" font-size="27" font-weight="700">Worlds</text>
+    <text x="275" y="681" font-size="18" fill="#657069">Represent · forecast · adapt</text>
+
+    <text x="275" y="893" font-size="27" font-weight="700">Grounded Physical</text>
+    <text x="275" y="928" font-size="27" font-weight="700">Agents</text>
+    <text x="275" y="971" font-size="18" fill="#657069">Perceive · reason · act</text>
+  </g>
+
+  <!-- The three themes form a mutually reinforcing bidirectional loop. -->
+  <g fill="none" stroke="#527866" stroke-width="3" stroke-linecap="round">
+    <path d="M 475 435 V 520" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+    <path d="M 475 725 V 810" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+    <path d="M 580 920 C 624 920 624 340 580 340" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+  </g>
+  <g fill="#526059" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="600" text-anchor="middle">
+    <text x="254" y="476">modeling ↔ discovery</text>
+    <text x="281" y="767">forecast ↔ feedback</text>
+    <text x="622" y="630" transform="rotate(-90 622 630)" font-size="15">experiments ↔ observations</text>
+  </g>
 </svg>

--- a/images/research/research-overview.svg
+++ b/images/research/research-overview.svg
@@ -1,81 +1,119 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
   <title id="title">Research framework</title>
-  <desc id="desc">A continuous research loop connects models of dynamic worlds, grounded physical agents, and agentic data scientists around agentic intelligence across digital and physical worlds.</desc>
+  <desc id="desc">Three mutually reinforcing themes form an upright triangle around agentic intelligence across digital-physical space.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#527866"/>
     </marker>
+    <marker id="mini-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="5.5" markerHeight="5.5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#678d7b"/>
+    </marker>
     <filter id="shadow" x="-15%" y="-15%" width="130%" height="140%">
-      <feDropShadow dx="0" dy="5" stdDeviation="8" flood-color="#26352d" flood-opacity="0.08"/>
+      <feDropShadow dx="0" dy="5" stdDeviation="8" flood-color="#26352d" flood-opacity="0.07"/>
     </filter>
   </defs>
 
   <rect x="1" y="1" width="1198" height="758" rx="32" fill="#f5f6f1" stroke="#dfe2da"/>
 
-  <path d="M 790 152 C 690 67 510 67 410 152" fill="none" stroke="#527866" stroke-width="3" marker-end="url(#arrow)"/>
-  <path d="M 246 276 C 266 403 352 510 456 568" fill="none" stroke="#527866" stroke-width="3" marker-end="url(#arrow)"/>
-  <path d="M 744 568 C 857 510 934 403 954 276" fill="none" stroke="#527866" stroke-width="3" marker-end="url(#arrow)"/>
-
-  <g fill="#f5f6f1">
-    <rect x="467" y="54" width="266" height="38" rx="19"/>
-    <rect x="100" y="406" width="300" height="38" rx="19"/>
-    <rect x="800" y="406" width="300" height="38" rx="19"/>
+  <!-- Each pair of themes reinforces the other; all three links are bidirectional. -->
+  <g fill="none" stroke="#527866" stroke-width="2.6" stroke-linecap="round">
+    <path d="M 480 228 C 388 302 344 413 412 522" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+    <path d="M 720 228 C 812 302 856 413 788 522" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+    <path d="M 428 570 A 220 220 0 0 0 772 570" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
   </g>
-  <g fill="#526059" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="600" text-anchor="middle">
-    <text x="600" y="79">observations &amp; consequences</text>
-    <text x="250" y="431">knowledge &amp; reusable workflows</text>
-    <text x="950" y="431">representations &amp; forecasts</text>
-  </g>
-
-  <g stroke="#aab9ae" stroke-width="2" stroke-dasharray="6 7">
-    <path d="M 505 292 L 395 239"/>
-    <path d="M 695 292 L 805 239"/>
-    <path d="M 600 488 L 600 545"/>
+  <g fill="#526059" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="600" text-anchor="middle">
+    <text x="278" y="365">modeling ↔ discovery</text>
+    <text x="922" y="365">experiments ↔ observations</text>
+    <text x="600" y="686">forecast ↔ feedback</text>
   </g>
 
   <g filter="url(#shadow)">
-    <rect x="70" y="105" width="340" height="170" rx="24" fill="#ffffff" stroke="#cbd6ce"/>
-    <rect x="790" y="105" width="340" height="170" rx="24" fill="#ffffff" stroke="#cbd6ce"/>
-    <rect x="430" y="545" width="340" height="170" rx="24" fill="#ffffff" stroke="#cbd6ce"/>
+    <rect x="420" y="50" width="360" height="170" rx="24" fill="#ffffff" stroke="#cbd6ce"/>
+    <rect x="60" y="530" width="360" height="170" rx="24" fill="#ffffff" stroke="#cbd6ce"/>
+    <rect x="780" y="530" width="360" height="170" rx="24" fill="#ffffff" stroke="#cbd6ce"/>
   </g>
 
-  <g transform="translate(104 139)" fill="none" stroke="#678d7b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
-    <ellipse cx="28" cy="10" rx="22" ry="8" fill="#edf3ef"/>
-    <path d="M 6 10 V 44 C 6 54 50 54 50 44 V 10"/>
-    <path d="M 6 27 C 6 37 50 37 50 27"/>
-    <circle cx="78" cy="18" r="8" fill="#edf3ef"/>
-    <circle cx="103" cy="43" r="8" fill="#edf3ef"/>
-    <path d="M 50 31 L 70 20 M 84 24 L 98 37"/>
+  <!-- Agentic data science: data, an agentic reasoning core, and an evaluated result. -->
+  <g transform="translate(448 91) scale(0.72)" fill="none" stroke="#678d7b" stroke-width="2.7" stroke-linecap="round" stroke-linejoin="round">
+    <ellipse cx="20" cy="14" rx="18" ry="7" fill="#edf3ef"/>
+    <path d="M 2 14 V 57 C 2 66 38 66 38 57 V 14 M 2 34 C 2 43 38 43 38 34"/>
+    <path d="M 39 37 H 51"/>
+    <circle cx="65" cy="37" r="14" fill="#f9fbf8"/>
+    <path d="M 59 32 L 65 26 L 71 32 M 59 42 L 65 48 L 71 42"/>
+    <path d="M 79 37 H 90"/>
+    <rect x="91" y="11" width="43" height="53" rx="7" fill="#f9fbf8"/>
+    <path d="M 99 52 L 108 40 L 116 46 L 127 29 M 99 56 H 128"/>
   </g>
-  <g transform="translate(824 139)" fill="none" stroke="#678d7b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M 4 45 H 110 M 20 5 V 62 M 82 5 V 62" stroke="#c3cec7" stroke-width="2"/>
-    <circle cx="25" cy="20" r="10" fill="#edf3ef"/>
-    <circle cx="79" cy="46" r="10" fill="#edf3ef"/>
-    <path d="M 36 22 C 50 24 58 31 68 40" marker-end="url(#arrow)"/>
+
+  <!-- World model: observations are encoded into latent dynamics and rolled forward. -->
+  <g transform="translate(84 568) scale(0.72)" fill="none" stroke="#678d7b" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="0" y="9" width="38" height="54" rx="6" fill="#edf3ef"/>
+    <path d="M 7 47 L 18 25 L 31 39"/>
+    <circle cx="7" cy="47" r="3" fill="#678d7b"/>
+    <circle cx="18" cy="25" r="3" fill="#678d7b"/>
+    <circle cx="31" cy="39" r="3" fill="#678d7b"/>
+
+    <circle cx="69" cy="36" r="20" fill="#f9fbf8"/>
+    <path d="M 57 40 C 59 25 75 21 81 32 C 87 43 74 53 62 47 Z"/>
+    <path d="M 55 30 C 65 34 74 45 80 51 M 52 41 C 63 39 76 34 86 29" stroke-width="1.8"/>
+    <circle cx="62" cy="29" r="2.5" fill="#678d7b"/>
+    <circle cx="78" cy="34" r="2.5" fill="#678d7b"/>
+    <circle cx="67" cy="48" r="2.5" fill="#678d7b"/>
+
+    <rect x="100" y="9" width="38" height="54" rx="6" fill="#f9fbf8" stroke-dasharray="5 4"/>
+    <path d="M 107 43 L 119 18 L 131 33"/>
+    <circle cx="107" cy="43" r="3" fill="#678d7b"/>
+    <circle cx="119" cy="18" r="3" fill="#678d7b"/>
+    <circle cx="131" cy="33" r="3" fill="#678d7b"/>
+    <path d="M 41 36 H 47 M 91 36 H 97" marker-end="url(#mini-arrow)"/>
   </g>
-  <g transform="translate(464 579)" fill="none" stroke="#678d7b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M 4 52 C 22 50 23 18 42 18 C 59 18 59 42 75 42 C 92 42 94 8 112 8"/>
-    <path d="M 4 62 H 116" stroke="#c3cec7" stroke-width="2"/>
-    <path d="M 18 4 V 62 M 58 4 V 62 M 98 4 V 62" stroke="#d8dfda" stroke-width="1.5"/>
+
+  <!-- Physical interaction: an agent acts on the world and learns from its consequences. -->
+  <g transform="translate(806 566) scale(0.72)" fill="none" stroke="#678d7b" stroke-width="2.7" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="0" y="24" width="38" height="38" rx="9" fill="#f9fbf8"/>
+    <circle cx="19" cy="43" r="7" fill="#edf3ef"/>
+    <circle cx="19" cy="43" r="2.5" fill="#678d7b"/>
+    <path d="M 19 16 V 24 M 19 62 V 70 M -8 43 H 0 M 38 43 H 46"/>
+
+    <path d="M 44 22 C 68 6 105 6 126 24" marker-end="url(#mini-arrow)"/>
+    <path d="M 126 67 C 101 82 66 82 44 63" marker-end="url(#mini-arrow)"/>
+
+    <path d="M 104 65 L 104 56 L 87 43 L 103 28"/>
+    <circle cx="104" cy="56" r="4" fill="#ffffff"/>
+    <circle cx="87" cy="43" r="4" fill="#ffffff"/>
+    <circle cx="103" cy="28" r="4" fill="#ffffff"/>
+    <path d="M 103 28 L 114 23 M 103 28 L 114 34"/>
+    <rect x="118" y="25" width="13" height="13" rx="2" fill="#edf3ef"/>
+    <path d="M 112 65 H 142 M 118 43 L 118 48 M 131 43 L 131 48" stroke="#91aa9c" stroke-width="1.8"/>
+    <path d="M 120 18 L 124 13 L 128 18" stroke="#91aa9c" stroke-width="1.8"/>
   </g>
 
   <g font-family="Arial, Helvetica, sans-serif" fill="#202622">
-    <text x="105" y="224" font-size="29" font-weight="700">Agentic Data Scientists</text>
-    <text x="105" y="253" font-size="17" fill="#657069">Analyze · discover · improve</text>
+    <text x="565" y="108" font-size="24" font-weight="700">Agentic Data</text>
+    <text x="565" y="137" font-size="24" font-weight="700">Scientists</text>
+    <text x="565" y="181" font-size="15" fill="#657069">Analyze · discover · improve</text>
 
-    <text x="825" y="224" font-size="29" font-weight="700">Grounded Physical Agents</text>
-    <text x="825" y="253" font-size="17" fill="#657069">Reason · coordinate · act</text>
+    <text x="205" y="585" font-size="22" font-weight="700">Models of Dynamic</text>
+    <text x="205" y="614" font-size="22" font-weight="700">Worlds</text>
+    <text x="205" y="657" font-size="15" fill="#657069">Represent · forecast · adapt</text>
 
-    <text x="465" y="664" font-size="29" font-weight="700">Models of Dynamic Worlds</text>
-    <text x="465" y="693" font-size="17" fill="#657069">Represent · forecast · adapt</text>
+    <text x="925" y="585" font-size="22" font-weight="700">Grounded Physical</text>
+    <text x="925" y="614" font-size="22" font-weight="700">Agents</text>
+    <text x="925" y="657" font-size="15" fill="#657069">Perceive · reason · act</text>
   </g>
 
-  <circle cx="600" cy="365" r="124" fill="#e8efea" stroke="#678d7b" stroke-width="2.5"/>
-  <circle cx="600" cy="365" r="106" fill="#f9faf7" stroke="#b8c7bd"/>
+  <circle cx="600" cy="365" r="132" fill="#e8efea" stroke="#678d7b" stroke-width="2.4"/>
+  <circle cx="600" cy="365" r="118" fill="#f9faf7" stroke="#b8c7bd"/>
   <g font-family="Arial, Helvetica, sans-serif" text-anchor="middle">
-    <text x="600" y="338" fill="#1d2822" font-size="27" font-weight="700">Agentic intelligence</text>
-    <text x="600" y="369" fill="#1d2822" font-size="21" font-weight="600">across digital &amp;</text>
-    <text x="600" y="396" fill="#1d2822" font-size="21" font-weight="600">physical worlds</text>
-    <text x="600" y="435" fill="#66736b" font-size="15" font-weight="600">UNDERSTAND · DECIDE · LEARN</text>
+    <text x="600" y="326" fill="#1d2822" font-size="21" font-weight="700">Agentic Intelligence</text>
+    <text x="600" y="355" fill="#1d2822" font-size="17" font-weight="600">Across Digital-Physical</text>
+    <text x="600" y="380" fill="#1d2822" font-size="17" font-weight="600">Space</text>
+    <g fill="#66736b" font-size="10" font-weight="700">
+      <text x="547" y="426">UNDERSTAND</text>
+      <circle cx="587" cy="422" r="1.7" fill="#8a958e"/>
+      <text x="614" y="426">DECIDE</text>
+      <circle cx="640" cy="422" r="1.7" fill="#8a958e"/>
+      <text x="669" y="426">LEARN</text>
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
## What changed
- add the long-term RA, intern, and visiting-student opportunity to Join Us
- refine the research relationship diagram and align the theme illustrations around world modeling and physical interaction
- make the GoatCounter script load directly after the footer counter and decouple the public count request from analytics-script loading

## Why
The research overview needed a clearer circular relationship among the three themes, and the public site-visit number was remaining at its fallback because the analytics script was absent from the deployed page.

## Validation
- Jekyll production build
- `ruby scripts/validate_site.rb`
- `ruby scripts/validate_publications.rb`
- XML validation for all research SVGs
- `git diff --check`
- GoatCounter public `TOTAL.json` endpoint confirmed reachable