### PR TITLE
Harden GoatCounter display

### DIFF
--- a/_includes/analytics-providers/goatcounter.html
+++ b/_includes/analytics-providers/goatcounter.html
@@ -1,18 +1,17 @@
 {% assign goatcounter_code = site.analytics.goatcounter.site_code | default: "" | strip %}
 {% assign production_hostname = site.analytics.goatcounter.production_hostname | default: "" | strip %}
 {% if goatcounter_code != "" and production_hostname != "" %}
+  <script data-goatcounter="https://{{ goatcounter_code }}.goatcounter.com/count"
+          async src="https://gc.zgo.at/count.js"></script>
   <script>
     (function () {
       if (window.location.hostname !== {{ production_hostname | jsonify }}) return;
 
       var endpoint = "https://{{ goatcounter_code }}.goatcounter.com";
-      var analytics = document.createElement("script");
-      analytics.async = true;
-      analytics.src = "https://gc.zgo.at/count.js";
-      analytics.dataset.goatcounter = endpoint + "/count";
 {% if site.page_views.enabled and site.page_views.provider == "goatcounter" %}
       var display = document.getElementById("goatcounter_site_views");
       if (display) {
+        display.textContent = "0";
         var request = new XMLHttpRequest();
         request.addEventListener("load", function () {
           if (request.status < 200 || request.status >= 300) return;
@@ -27,7 +26,6 @@
         request.send();
       }
 {% endif %}
-      document.body.appendChild(analytics);
     }());
   </script>
 {% endif %}


### PR DESCRIPTION
Use GoatCounter's documented static script integration and show a numeric fallback while the public total loads.\n\nValidated with the production Jekyll build, site validator, publication validator, and generated-script checks.