### PR TITLE
Keep GoatCounter script valid after minification

### DIFF
--- a/_includes/analytics-providers/goatcounter.html
+++ b/_includes/analytics-providers/goatcounter.html
@@ -19,7 +19,7 @@
           try {
             display.textContent = JSON.parse(request.responseText).count;
           } catch (error) {
-            // Keep the neutral fallback when the counter response is unavailable.
+            /* Keep the numeric fallback when the counter response is unavailable. */
           }
         });
         request.open("GET", endpoint + "/counter/TOTAL.json");


### PR DESCRIPTION
Replace the inline line comment with a block comment so GitHub Pages HTML minification cannot comment out the remainder of the counter script.\n\nValidated with a production Jekyll build and both repository validators.