### PR TITLE
Data-drive site content

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -1,0 +1,27 @@
+name: Content validation
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Validate structured site content
+        run: ruby scripts/validate_content.rb
+
+      - name: Validate publication data and assets
+        run: ruby scripts/validate_publications.rb

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,176 @@
+# 内容更新指南
+
+网站的高频内容集中在 `_data/*.yml`。日常更新通常只需要编辑对应的数据文件；只有调整页面布局、栏目结构或视觉样式时，才需要修改 `_pages/`、`_includes/` 或 `_sass/`。
+
+## 快速索引
+
+| 要更新的内容 | 数据文件 |
+| --- | --- |
+| 姓名、简介、头像、主页与页脚链接 | `_data/profile.yml` |
+| 首页研究概览、Join Us | `_data/home.yml` |
+| Recent Updates 与完整 News | `_data/news.yml` |
+| Research 总述、关系图、主题和 related work | `_data/research.yml` |
+| Current / Past Courses | `_data/teaching.yml` |
+| Student Achievements 与 Alumni | `_data/students.yml` |
+| Editorial、Conference、Journal Service | `_data/services.yml` |
+| Talks and Presentations | `_data/talks.yml` |
+| Selected Publications 卡片 | `_data/selected_publications.yml` |
+| Full Publication List | `_data/publications.yml` |
+
+YAML 使用两个空格缩进，不使用 Tab。包含冒号、井号或特殊符号的短文本建议用双引号包住；较长段落使用 `>-`。更新有顺序的数据时，把最新条目放在最前面。
+
+## 常用更新样例
+
+### 1. 添加一条 News，并在首页显示
+
+在 `_data/news.yml` 的 `items:` 下按时间倒序插入：
+
+```yaml
+  - date: "2026-08-15"
+    display: Aug 2026
+    featured: true
+    summary: >-
+      Two papers were accepted to **NeurIPS 2026**.
+    content: >-
+      Two papers were accepted to **NeurIPS 2026** on [topic A](https://example.com/a) and [topic B](https://example.com/b).
+```
+
+- `featured: true`：参与首页 Recent Updates 的展示；首页只取最新五条 featured news。
+- `summary`：可选，首页使用的精简版；News 页面始终使用 `content`。
+- `date`：支持 `YYYY`、`YYYY-MM` 或 `YYYY-MM-DD`，并用于排序与 HTML 时间语义。
+
+### 2. 学期结束后更新 Teaching
+
+把已经结束的课程从 `current:` 移到 `past:` 最上方，再填写新学期课程：
+
+```yaml
+current:
+  - term: 2027 Spring
+    code: AIAA 1234
+    title: Example Course
+
+past:
+  - term: 2026 Fall
+    code: AIAA 3111
+    title: Introduction to Data Mining
+```
+
+同一学期、同一课程代码不能重复。
+
+### 3. 添加 Student Achievement
+
+在 `_data/students.yml` 的 `achievements:` 中按年份倒序插入：
+
+```yaml
+  - name: Student Name
+    year: 2027
+    award: HKUST(GZ) AI Thrust 2027 Best Research Award
+    url: https://example.com/award
+```
+
+`url` 可省略。显示时保持“姓名 + 奖项名称”的现有格式，`year` 主要用于校验排序。
+
+### 4. 添加 Alumni
+
+学生加入 `alumni.students`：
+
+```yaml
+    - name: Student Name
+      degree: Ph.D.
+      year: 2027
+      destination: Assistant Professor, Example University
+```
+
+RA、intern 或 visiting student 加入 `alumni.assistants`：
+
+```yaml
+    - name: Student Name
+      role: Research Assistant
+      background: Undergraduate, Example University
+      destination: Ph.D. student, Example University
+```
+
+`destination` 对 RA / intern 可省略。
+
+### 5. 更新 Research theme
+
+修改 `_data/research.yml` 中对应 theme；页面标题、介绍、配图和 related work 会同步更新：
+
+```yaml
+  - id: grounded-physical-agents
+    title: Grounded Physical Agents
+    image: /images/research/grounded-physical-agents.svg
+    description: >-
+      A concise description of the theme.
+    related:
+      - title: Project Name
+        url: https://arxiv.org/abs/0000.00000
+```
+
+`id` 同时作为页面锚点，应保持稳定；除非主题本身改名，不建议修改。
+
+### 6. 更新 Join Us
+
+在 `_data/home.yml` 的 `join.opportunities` 中编辑或增加卡片：
+
+```yaml
+    - title: Visiting students
+      content: >-
+        A concise description with an [application link](https://example.com/).
+```
+
+`content` 支持 Markdown 链接、粗体和斜体。
+
+### 7. 添加 Talk
+
+在 `_data/talks.yml` 顶部按日期倒序加入：
+
+```yaml
+  - title: Example Talk
+    format: Invited Talk
+    venue: Example Conference
+    venue_url: https://example.com/
+    location: Guangzhou, China
+    date: "2027-01-15"
+```
+
+`venue_url` 和 `location` 可省略。
+
+### 8. 添加 Selected Publication
+
+在 `_data/selected_publications.yml` 的相应主题 `papers:` 下加入卡片：
+
+```yaml
+    - short_title: Project Name
+      venue: KDD 2027
+      topic: Agentic data science
+      title: "Full Paper Title"
+      url: https://arxiv.org/abs/0000.00000
+      bibtex: /files/bibtex/project-name.bib
+      image: /images/publications/project-name.png
+      image_alt: Brief factual description of the figure
+      authors: "First Author and <strong>Hao Liu</strong>"
+      summary: "One sentence explaining the problem, approach, and contribution."
+      links:
+        - label: Code
+          url: https://github.com/usail-hkust/project-name
+```
+
+同时需要：
+
+1. 把 BibTeX 文件放入 `files/bibtex/`；
+2. 把卡片图片放入 `images/publications/`；
+3. 在 `_data/publications.yml` 相应年份中加入完整引用。
+
+如果没有 code、demo 或 project page，可省略 `links`。`image_alt` 应描述图片内容，而不是重复论文标题。
+
+## 更新后检查
+
+```bash
+bundle exec jekyll build --destination /tmp/raymondhliu-site
+ruby scripts/validate_content.rb
+ruby scripts/validate_publications.rb
+ruby scripts/validate_site.rb /tmp/raymondhliu-site
+```
+
+校验会检查必填字段、日期排序、重复条目、本地文件、链接格式、论文附件，以及 YAML 条目是否完整渲染到生成页面。最后在桌面端和移动端各快速查看首页、Research、Publications 和本次修改的页面。

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ Source for [raymondhliu.github.io](https://raymondhliu.github.io), built with Je
 ## Content map
 
 - `_pages/`: page content and structure
+- `_data/profile.yml`: bio, portrait, profile links, and footer links
+- `_data/home.yml`: homepage research summary and Join Us opportunities
+- `_data/news.yml`: shared source for homepage updates and the full News archive
+- `_data/teaching.yml`: current and past courses
+- `_data/students.yml`: student achievements and alumni
+- `_data/services.yml`: editorial, conference, and journal service
+- `_data/research.yml`: research framework, perspectives, themes, and related work
+- `_data/talks.yml`: talks and presentations
 - `_data/publications.yml`: full publication list
 - `_data/selected_publications.yml`: selected-publication cards
 - `_sass/_homepage.scss`: site-specific visual system and responsive layout
@@ -29,8 +37,19 @@ After content or layout changes:
 ```bash
 bundle exec jekyll build --destination /tmp/raymondhliu-site
 ruby scripts/validate_site.rb /tmp/raymondhliu-site
+ruby scripts/validate_content.rb
 ruby scripts/validate_publications.rb
 ```
+
+GitHub Actions also runs the structured-content and publication checks automatically on every push and pull request.
+
+## Updating content
+
+Frequently edited content lives in `_data/` rather than page templates. Add or edit a YAML entry, keep the existing field names, and run the validation commands above. Page files in `_pages/` should normally change only when the layout or information architecture changes.
+
+See [MAINTENANCE.md](MAINTENANCE.md) for a Chinese content map and copy-ready update examples for news, courses, students, research themes, talks, Join Us, and publications.
+
+News items are listed once in `_data/news.yml`. Set `featured: true` to make an item eligible for the five-entry homepage list, and add an optional `summary` when the homepage wording should be shorter than the archive entry. Inline links and emphasis use Markdown.
 
 If JavaScript sources change, install the pinned build dependency and regenerate the bundle:
 

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,8 +1,0 @@
-# Authors
-
-Name Name:
-  name        : "Hao Liu"
-  uri         : "https://raymondhliu.github.io"
-  email       : "liuh[at]ust[dot]hk"
-  bio         : "Hao Liu."
-  avatar      : "haoliu.jpg"

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -1,0 +1,30 @@
+research:
+  heading: Building agentic systems for complex digital and physical worlds.
+  lead: My recent interest spans agentic data science, scientific discovery, and decision-making in dynamic real-world systems.
+  capabilities:
+    - number: "01"
+      title: Understand complex worlds
+      description: Learn transferable representations of complex, evolving environments across scales and domains.
+    - number: "02"
+      title: Make grounded decisions
+      description: Reason with evidence, tools, collaborators, and physical constraints to act reliably in real-world environments.
+    - number: "03"
+      title: Learn through interaction
+      description: Improve analytical and scientific workflows through execution feedback, reusable skills, and accumulated experience.
+  link:
+    label: Explore research themes and related work →
+    url: /research/
+
+join:
+  eyebrow: Join us
+  title: Work with us.
+  opportunities:
+    - title: Postdoc and PhD students
+      content: >-
+        Postdoctoral / Research Associate positions are available. Prospective Ph.D. students whose interests align with our research are also welcome. Please email your CV and representative work to [liuh@ust.hk](mailto:liuh@ust.hk).
+    - title: RBM students
+      content: >-
+        Please apply directly through the [HKUST(GZ) Online Admission System](https://pgoas.hkust-gz.edu.cn/). After receiving an offer, you are welcome to contact me to discuss research fit; joining the group as an RA before making a final decision is encouraged. Please read the [Guidelines & Expectations](/files/MPhil_Guideline.pdf).
+    - title: RAs, interns, and visiting students
+      content: >-
+        We welcome applications year-round from students who can commit for at least six months. We provide a stipend, computing resources, and close research mentorship. Please email your CV, availability, and a brief description of your research interests to [liuh@ust.hk](mailto:liuh@ust.hk).

--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,0 +1,100 @@
+items:
+  - date: "2026-07"
+    display: Jul 2026
+    featured: true
+    content: >-
+      Call for papers: the [Frontiers of AI and Data Science Competitions](https://link.springer.com/collections/fhbghibigc) special issue in **Frontiers of Computer Science** is now open for submissions.
+  - date: "2026-05-18"
+    display: May 2026
+    featured: true
+    summary: >-
+      New papers at **KDD 2026** on [autonomous data science, travel agents, extreme-weather forecasting, and flood forecasting](/publications/full/).
+    content: >-
+      New papers at **KDD 2026** and **ICML 2026** on autonomous data science, travel agents, efficient agent reasoning, and flood forecasting.
+  - date: "2026-01"
+    display: Jan 2026
+    featured: true
+    content: >-
+      New work at **ICLR 2026** and **The Web Conference 2026** on [multimodal scientific discovery](https://openreview.net/forum?id=kZHSvETWdi), [cooperative urban agents](https://arxiv.org/abs/2503.11739), and [spatiotemporal reasoning](https://arxiv.org/abs/2505.17572).
+  - date: "2025-11-25"
+    display: Nov 2025
+    content: >-
+      New papers at **KDD 2026** and **AAAI 2026** on extreme-weather forecasting, subseasonal-to-seasonal weather forecasting, travel-time estimation, and recommendation.
+  - date: "2025-09-25"
+    display: Sep 2025
+    featured: true
+    content: >-
+      Three papers were accepted to **NeurIPS 2025**, exploring agentic scientific discovery, mathematical modeling agents, and test-time reasoning.
+  - date: "2025-08-05"
+    display: Aug 2025
+    featured: true
+    content: >-
+      [LLMLight](https://arxiv.org/abs/2312.16044) received the [KDD 2025 Audience Appreciation Award](https://kdd2025.kdd.org/awards/).
+  - date: "2025-06-01"
+    display: Jun 2025
+    content: >-
+      Congratulations to Jindong Han on joining Shandong University as an Associate Professor.
+  - date: "2025-05-31"
+    display: May 2025
+    content: >-
+      Received an Outstanding Reviewer recognition from **KDD 2025**.
+  - date: "2025-05-20"
+    display: May 2025
+    content: >-
+      Five papers were accepted to **KDD 2025** on time-series modeling, nuclear-radiation forecasting, ride-hailing agents, and scientific retrieval.
+  - date: "2025-04-30"
+    display: Apr 2025
+    content: >-
+      One paper on language-model-empowered spatiotemporal forecasting was accepted to **IJCAI 2025**.
+  - date: "2025-04-25"
+    display: Apr 2025
+    content: >-
+      Congratulations to Weijia Zhang on receiving the 2025 Baidu Scholarship.
+  - date: "2025-04-15"
+    display: Apr 2025
+    content: >-
+      The LLMLight team received a Special Award and Gold Medal at the International Exhibition of Inventions Geneva 2025.
+  - date: "2025-03-16"
+    display: Mar 2025
+    content: >-
+      Our work on compact pre-trained spatiotemporal predictive models was accepted to **VLDB 2025**.
+  - date: "2025-01-23"
+    display: Jan 2025
+    content: >-
+      Three papers were accepted to **ICLR 2025** and **The Web Conference 2025**, including a spotlight on retrieval utility measurement for RAG.
+  - date: "2024-12-19"
+    display: Dec 2024
+    content: >-
+      Our group received reviewer recognitions from **KDD 2025**.
+  - date: "2024-11-20"
+    display: Nov 2024
+    content: >-
+      Three papers were accepted to **KDD 2025** on traffic-control agents, automated spatiotemporal forecasting, and graph adaptation.
+  - date: "2024-09-26"
+    display: Sep 2024
+    content: >-
+      Two papers were accepted to **NeurIPS 2024** on urban knowledge-graph agents and LLM jailbreak evaluation.
+  - date: "2024-09-20"
+    display: Sep 2024
+    content: >-
+      Our IEEE recommended practice for applying knowledge graphs to talent services was formally published.
+  - date: "2024-09-13"
+    display: Sep 2024
+    content: >-
+      Started serving as an Associate Editor of **IEEE Transactions on Big Data**.
+  - date: "2024-08-30"
+    display: Aug 2024
+    content: >-
+      [BigST](https://www.vldb.org/pvldb/vol17/p1081-han.pdf) received a **VLDB 2024 Best Research Paper Nomination**.
+  - date: "2024-08-27"
+    display: Aug 2024
+    content: >-
+      We presented a tutorial on [Urban Foundation Models](https://github.com/usail-hkust/Awesome-Urban-Foundation-Models) at **KDD 2024**.
+  - date: "2024-05-17"
+    display: May 2024
+    content: >-
+      Three papers were accepted to **KDD 2024** on congestion prediction, federated graph learning, and irregular traffic forecasting.
+  - date: "2024-05-01"
+    display: May 2024
+    content: >-
+      Our work on irregular multivariate time-series forecasting was accepted to **ICML 2024**.

--- a/_data/profile.yml
+++ b/_data/profile.yml
@@ -1,0 +1,24 @@
+name: Hao Liu
+affiliation: HKUST(GZ)
+bio: >-
+  I am an Associate Professor in the Artificial Intelligence Thrust at The Hong Kong University of Science and Technology (Guangzhou), and an affiliated faculty member at HKUST. Before joining HKUST(GZ), I was a Research Scientist at Baidu Research.
+portrait:
+  src: /images/haoliu.jpg
+  alt: Portrait of Hao Liu
+links:
+  - label: Join Us
+    url: "#join-us"
+    internal: true
+  - label: Google Scholar
+    url: https://scholar.google.com/citations?user=66KKZR4AAAAJ&hl=en
+  - label: GitHub
+    url: https://github.com/usail-hkust
+  - label: Email
+    url: mailto:liuh@ust.hk
+footer_links:
+  - label: Google Scholar
+    url: https://scholar.google.com/citations?user=66KKZR4AAAAJ&hl=en
+  - label: GitHub
+    url: https://github.com/usail-hkust
+  - label: Email
+    url: mailto:liuh@ust.hk

--- a/_data/research.yml
+++ b/_data/research.yml
@@ -1,0 +1,65 @@
+lead: >-
+  We study agentic intelligence across digital and physical worlds: systems that understand complex environments, make grounded decisions, and learn from the consequences of action.
+
+framework:
+  desktop_image: /images/research/research-overview.svg
+  mobile_image: /images/research/research-overview-mobile.svg
+  alt: Research framework connecting models of dynamic worlds, grounded physical agents, and agentic data scientists around agentic intelligence across digital-physical space.
+  caption: >-
+    The three themes are mutually reinforcing: data-science agents build and interrogate world models, models guide physical action, and interaction returns evidence that improves both models and workflows.
+
+perspectives:
+  - title: "Foundation Models for Scientific Discovery: From Paradigm Enhancement to Paradigm Transition"
+    url: http://www.techrxiv.org/doi/full/10.36227/techrxiv.174953071.19189612/v1
+  - title: "Urban Foundation Models: A Survey"
+    url: https://github.com/usail-hkust/Awesome-Urban-Foundation-Models
+  - title: "Large Language Model Powered Intelligent Urban Agents: Concepts, Capabilities, and Applications"
+    url: https://arxiv.org/abs/2507.00914
+
+themes:
+  - id: agentic-data-scientists
+    title: Agentic Data Scientists
+    image: /images/research/agentic-data-scientists.svg
+    description: >-
+      We develop agents that turn open-ended questions into reproducible end-to-end data science and scientific workflows. Beyond general agent capabilities such as planning, tool use, memory, and self-improvement, we emphasize data-centric intelligence: actively exploring, cleaning, and grounding reasoning in heterogeneous and imperfect data; making methodological choices through execution feedback; and reliably coordinating the full lifecycle from data preparation and modeling to evaluation, interpretation, and deployment.
+    related:
+      - title: EvoDS
+        url: https://arxiv.org/abs/2606.03841
+      - title: MM-Agent
+        url: https://arxiv.org/abs/2505.14148
+      - title: MoSciBench
+        url: https://openreview.net/forum?id=kZHSvETWdi
+  - id: grounded-physical-agents
+    title: Grounded Physical Agents
+    image: /images/research/grounded-physical-agents.svg
+    description: >-
+      We build agents that perceive and act through spatiotemporal signals, tools, simulators, APIs, and multi-agent interaction. Real-world systems—especially cities—provide a demanding testbed where decisions must respect physical constraints, uncertainty, coordination requirements, and downstream consequences.
+    related:
+      - title: DeepTravel
+        url: https://arxiv.org/abs/2509.21842
+      - title: USTBench
+        url: https://arxiv.org/abs/2505.17572
+      - title: CoLLMLight
+        url: https://arxiv.org/abs/2503.11739
+      - title: CityNav
+        url: https://arxiv.org/abs/2510.07825
+      - title: LLMLight
+        url: https://arxiv.org/abs/2312.16044
+  - id: models-of-dynamic-worlds
+    title: Models of Dynamic Worlds
+    image: /images/research/models-dynamic-worlds.svg
+    description: >-
+      We study predictive models that learn transferable representations of complex, evolving environments. Our goal is to capture dynamics across scales, domains, and observation patterns while retaining the efficiency, robustness, and adaptability needed for scientific and operational use.
+    related:
+      - title: UniExtreme
+        url: https://arxiv.org/abs/2508.01426
+      - title: CompactST
+        url: https://www.vldb.org/pvldb/vol18/p2149-han.pdf
+      - title: BigST
+        url: https://www.vldb.org/pvldb/vol17/p1081-han.pdf
+      - title: t-PatchGNN
+        url: https://proceedings.mlr.press/v235/zhang24bw.html
+
+full_publications:
+  label: View full publication list →
+  url: /publications/full/

--- a/_data/services.yml
+++ b/_data/services.yml
@@ -1,0 +1,61 @@
+editorial_and_organizational:
+  - organization: IEEE Transactions on Big Data
+    url: https://www.computer.org/csdl/journal/bd
+    role: Associate Editor
+  - organization: npj Artificial Intelligence
+    url: https://www.nature.com/npjai/editors
+    role: Editorial Board Member
+  - organization: Journal of Computer Science and Technology
+    url: https://jcst.ict.ac.cn/
+    role: Young Scientist Editor
+  - organization: ACM Transactions on Intelligent Systems and Technology
+    url: https://dl.acm.org/journal/tist
+    role: Guest Editor
+  - organization: Frontiers of Computer Science
+    url: https://link.springer.com/journal/11704
+    role: Guest Editor
+  - organization: Encyclopedia of GIS
+    url: https://link.springer.com/referencework/10.1007/978-0-387-35973-1
+    role: Field Editor
+  - organization: IJCAI 2025
+    url: https://2025.ijcai.org/
+    role: Competition Chair
+  - organization: VLDB 2024
+    url: https://vldb.org/2024/
+    role: Local Chair
+  - organization: IEEE P3154 Standard Working Group
+    role: Secretary
+  - organization: KDD Cup 2019 · Regular ML Track
+    role: Co-organizer
+
+conferences:
+  - name: KDD
+    years: 2019–2026
+  - name: ACL Rolling Review
+    years: 2023–2026
+  - name: IJCAI
+    years: 2021–2024
+  - name: AAAI
+    years: 2020–2026
+  - name: NeurIPS
+    years: 2023–2026
+  - name: ICLR
+    years: 2023–2026
+  - name: The Web Conference
+    years: "2023"
+  - name: ICDM
+    years: 2023–2025
+  - name: SDM
+    years: 2021, 2023
+  - name: ECAI
+    years: "2025"
+
+journals:
+  - IEEE Transactions on Knowledge and Data Engineering
+  - ACM Transactions on Knowledge Discovery from Data
+  - ACM Transactions on Intelligent Systems and Technology
+  - Data & Knowledge Engineering
+  - IEEE Transactions on Big Data
+  - IEEE Transactions on Cybernetics
+  - Scientific Reports
+  - Transportation Research Part C

--- a/_data/students.yml
+++ b/_data/students.yml
@@ -1,0 +1,130 @@
+achievements:
+  - name: Tengfei Lyu
+    year: 2026
+    award: HKUST(GZ) AI Thrust 2026 Best Research Award
+  - name: Yansong Ning
+    year: 2026
+    award: HKUST(GZ) AI Thrust 2026 Rising Star Award
+  - name: Fan Liu
+    year: 2026
+    award: 2026 Lizhi Scholarship
+  - name: Fan Liu
+    year: 2025
+    award: HKUST(GZ) AI Thrust 2025 Best Research Award
+  - name: Weijia Zhang
+    year: 2025
+    award: 2025 Baidu Scholarship
+  - name: Siqi Lai
+    year: 2025
+    award: Special Award of International Exhibition of Inventions Geneva 2025
+    url: /images/trophy.jpg
+  - name: Siqi Lai
+    year: 2025
+    award: KDD 2025 Audience Appreciation Award
+    url: https://kdd2025.kdd.org/awards/
+  - name: Jindong Han
+    year: 2025
+    award: 2025 National Young Talent Plan
+  - name: Jindong Han
+    year: 2024
+    award: HKUST AIS 2024 Best Research Award
+  - name: Jindong Han
+    year: 2024
+    award: VLDB 2024 Best Research Paper Nomination Award
+  - name: Fan Liu
+    year: 2024
+    award: HKUST(GZ) AI Thrust 2024 Rising Star Award
+  - name: Weijia Zhang
+    year: 2023
+    award: HKUST(GZ) AI Thrust 2023 Best Research Award
+
+alumni:
+  students:
+    - name: Weijia Zhang
+      degree: Ph.D.
+      year: 2026
+      destination: Ant Group (Talent Plan)
+    - name: Ruiqian Han
+      degree: M.Phil.
+      year: 2026
+      destination: DiDi Chuxing
+    - name: Hao Wang
+      degree: M.Phil.
+      year: 2026
+      destination: Ph.D. student, The Hong Kong Polytechnic University
+    - name: Yuxuan Fan
+      degree: M.Phil.
+      year: 2026
+      destination: Ph.D. student, Nanyang Technological University
+    - name: Jindong Han
+      degree: Ph.D.
+      year: 2025
+      destination: Professor, Shandong University
+    - name: Zhao Xu
+      degree: M.Phil.
+      year: 2025
+      destination: Ph.D. student, UCLA
+    - name: Tianrui Song
+      degree: M.Phil.
+      year: 2025
+      destination: Master's student, King's College London
+    - name: Wenshuo Chao
+      degree: M.Phil.
+      year: 2024
+      destination: Quant Researcher @ Private Fund
+    - name: Ziyang Wu
+      degree: M.Phil.
+      year: 2024
+      destination: China Grid
+    - name: Ruohong Liu
+      degree: M.Phil.
+      year: 2024
+      destination: Ph.D. student, University of Oxford
+    - name: Qingyan Zhu
+      degree: M.Phil.
+      year: 2022
+      destination: NIO Inc.
+  assistants:
+    - name: Xiaolong Jin
+      role: Research Assistant
+      background: Undergraduate, USTC
+      destination: Ph.D. student, Purdue University
+    - name: Weilin Lin
+      role: Research Assistant
+      background: M.Sc., City University of Hong Kong
+      destination: Ph.D. student, HKUST(GZ)
+    - name: Zixuan Weng
+      role: Research Assistant
+      background: Undergraduate, Beijing Jiaotong University
+      destination: Ph.D. student, Georgia Tech
+    - name: Can Chen
+      role: Intern
+      background: Undergraduate, USTC
+      destination: Ph.D. student, McGill University
+    - name: Wei Fan
+      role: Intern
+      background: Ph.D., University of Central Florida
+      destination: Lecturer, University of Auckland
+    - name: Qingyu Guo
+      role: Intern
+      background: Ph.D. student, HKUST
+      destination: Tencent
+    - name: Carter Blum
+      role: Intern
+      background: Master's student, University of Minnesota
+      destination: Bloomberg
+    - name: Ying Xu
+      role: Intern
+      background: Ph.D. student, National University of Defense Technology
+    - name: Pengfei Wang
+      role: Intern
+      background: Ph.D., Chinese Academy of Sciences
+      destination: Associate Researcher, Chinese Academy of Sciences
+    - name: Zixuan Yuan
+      role: Intern
+      background: Ph.D., Rutgers University
+      destination: Assistant Professor, HKUST(GZ)
+    - name: Ting Li
+      role: Intern
+      background: Master's student, National University of Defense Technology
+      destination: JD Digits

--- a/_data/talks.yml
+++ b/_data/talks.yml
@@ -1,0 +1,31 @@
+items:
+  - title: "Next Generation Smart Transportation: Research and Applications"
+    format: Invited Talk
+    venue: 2020 China Collegiate Computing Contest - Artificial Intelligence Innovation Contest
+    date: "2020-08-28"
+  - title: "Hydra: A Personalized and Context-Aware Multi-Modal Transportation Recommendation System"
+    format: Oral Presentation
+    venue: KDD 2019
+    location: Alaska, USA
+    date: "2019-08-06"
+  - title: "Baidu’s Initiative in Creating the Future of Intelligent Transportation"
+    format: Invited talk
+    venue: World AI Summit Americas
+    venue_url: https://americas.worldsummit.ai/
+    location: Montreal, Canada
+    date: "2019-04-11"
+  - title: Baidu AI
+    format: Recruitment talk
+    venue: Tsinghua University
+    location: Beijing, China
+    date: "2019-03-18"
+  - title: Baidu Brain 3.0
+    format: Invited talk
+    venue: University of Macau
+    location: Macau, China
+    date: "2019-02-15"
+  - title: Joint Representation Learning for Multi-Modal Transportation Recommendation
+    format: Oral Presentation
+    venue: AAAI 2019
+    location: Hawaii, USA
+    date: "2019-01-29"

--- a/_data/teaching.yml
+++ b/_data/teaching.yml
@@ -1,0 +1,33 @@
+current:
+  - term: 2026 Fall
+    code: AIAA 3111
+    title: Introduction to Data Mining
+  - term: 2026 Fall
+    code: UCUG 1002
+    title: Artificial Intelligence General Education
+
+past:
+  - term: 2026 Spring
+    code: UCMP 6010
+    title: Cross-disciplinary Research Methods I
+  - term: 2025 Fall
+    code: AIAA 3111
+    title: Introduction to Data Mining
+  - term: 2025 Fall
+    code: UCMP 6010
+    title: Cross-disciplinary Research Methods I
+  - term: 2025 Spring
+    code: UCMP 6010
+    title: Cross-disciplinary Research Methods I
+  - term: 2024 Fall
+    code: UFUG 1601
+    title: Introduction to Computer Science
+  - term: 2024 Fall
+    code: UCMP 6010
+    title: Cross-disciplinary Research Methods I
+  - term: 2023 Fall
+    code: AIAA 5028
+    title: Machine Learning on Graphs
+  - term: 2022 Fall
+    code: AIAA 5028
+    title: Machine Learning on Graphs

--- a/_includes/course-list.html
+++ b/_includes/course-list.html
@@ -1,0 +1,8 @@
+<ul class="course-history{% if include.current %} course-history--current{% endif %}">
+  {% for course in include.courses %}
+    <li>
+      <time>{{ course.term }}</time>
+      <div><strong>{{ course.code }}</strong><span>{{ course.title }}</span></div>
+    </li>
+  {% endfor %}
+</ul>

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,16 +1,15 @@
 {% include base_path %}
+{% assign profile = site.data.profile %}
 
 <div class="site-footer">
   <p class="site-footer__meta">
-    <span class="site-footer__copyright">&copy; {{ site.time | date: '%Y' }} Hao Liu <span class="site-footer__separator" aria-hidden="true">·</span> HKUST(GZ)</span>
+    <span class="site-footer__copyright">&copy; {{ site.time | date: '%Y' }} {{ profile.name }} <span class="site-footer__separator" aria-hidden="true">·</span> {{ profile.affiliation }}</span>
     {% if site.page_views.enabled %}
       <span class="site-footer__views">Site visits <span id="goatcounter_site_views" aria-live="polite">—</span></span>
     {% endif %}
   </p>
   <nav aria-label="Footer links">
-    <a href="https://scholar.google.com/citations?user=66KKZR4AAAAJ&amp;hl=en">Google Scholar</a>
-    <a href="https://github.com/usail-hkust">GitHub</a>
-    <a href="mailto:liuh@ust.hk">Email</a>
+    {% for link in profile.footer_links %}<a href="{{ link.url | escape }}">{{ link.label }}</a>{% endfor %}
   </nav>
 </div>
 

--- a/_includes/inline-markdown.html
+++ b/_includes/inline-markdown.html
@@ -1,0 +1,1 @@
+{% assign inline_markdown = include.content | markdownify | strip %}{{ inline_markdown | remove_first: '<p>' | remove_first: '</p>' }}

--- a/_includes/news-list.html
+++ b/_includes/news-list.html
@@ -1,0 +1,14 @@
+{% assign rendered_news = 0 %}
+<ul class="home-updates{% if include.archive %} home-updates--archive{% endif %}">
+  {% for item in site.data.news.items %}
+    {% if include.featured_only and item.featured != true %}{% continue %}{% endif %}
+    {% if include.limit and rendered_news >= include.limit %}{% break %}{% endif %}
+    {% assign news_content = item.content %}
+    {% if include.use_summary and item.summary %}{% assign news_content = item.summary %}{% endif %}
+    <li class="home-update">
+      <time datetime="{{ item.date }}">{{ item.display }}</time>
+      <p>{% include inline-markdown.html content=news_content %}</p>
+    </li>
+    {% assign rendered_news = rendered_news | plus: 1 %}
+  {% endfor %}
+</ul>

--- a/_includes/selected-research-theme.html
+++ b/_includes/selected-research-theme.html
@@ -1,36 +1,18 @@
 <div class="home-subsection" aria-labelledby="selected-research-heading">
   <h2 class="home-subsection__heading" id="selected-research-heading">Research themes</h2>
 
-  <article class="home-project" id="agentic-data-scientists">
-    <div class="home-project__identity">
-      <img class="home-project__visual" src="{{ site.baseurl }}/images/research/agentic-data-scientists.svg" alt="" loading="lazy">
-      <h3 class="home-project__theme">Agentic Data Scientists</h3>
-    </div>
-    <div class="home-project__content">
-      <p class="home-project__question">We develop agents that turn open-ended questions into reproducible end-to-end data science and scientific workflows. Beyond general agent capabilities such as planning, tool use, memory, and self-improvement, we emphasize data-centric intelligence: actively exploring, cleaning, and grounding reasoning in heterogeneous and imperfect data; making methodological choices through execution feedback; and reliably coordinating the full lifecycle from data preparation and modeling to evaluation, interpretation, and deployment.</p>
-      <p class="home-project__related"><strong>Related work:</strong> <a href="https://arxiv.org/abs/2606.03841">EvoDS</a> · <a href="https://arxiv.org/abs/2505.14148">MM-Agent</a> · <a href="https://openreview.net/forum?id=kZHSvETWdi">MoSciBench</a></p>
-    </div>
-  </article>
-
-  <article class="home-project" id="grounded-physical-agents">
-    <div class="home-project__identity">
-      <img class="home-project__visual" src="{{ site.baseurl }}/images/research/grounded-physical-agents.svg" alt="" loading="lazy">
-      <h3 class="home-project__theme">Grounded Physical Agents</h3>
-    </div>
-    <div class="home-project__content">
-      <p class="home-project__question">We build agents that perceive and act through spatiotemporal signals, tools, simulators, APIs, and multi-agent interaction. Real-world systems—especially cities—provide a demanding testbed where decisions must respect physical constraints, uncertainty, coordination requirements, and downstream consequences.</p>
-      <p class="home-project__related"><strong>Related work:</strong> <a href="https://arxiv.org/abs/2509.21842">DeepTravel</a> · <a href="https://arxiv.org/abs/2505.17572">USTBench</a> · <a href="https://arxiv.org/abs/2503.11739">CoLLMLight</a> · <a href="https://arxiv.org/abs/2510.07825">CityNav</a> · <a href="https://arxiv.org/abs/2312.16044">LLMLight</a></p>
-    </div>
-  </article>
-
-  <article class="home-project" id="models-of-dynamic-worlds">
-    <div class="home-project__identity">
-      <img class="home-project__visual" src="{{ site.baseurl }}/images/research/models-dynamic-worlds.svg" alt="" loading="lazy">
-      <h3 class="home-project__theme">Models of Dynamic Worlds</h3>
-    </div>
-    <div class="home-project__content">
-      <p class="home-project__question">We study predictive models that learn transferable representations of complex, evolving environments. Our goal is to capture dynamics across scales, domains, and observation patterns while retaining the efficiency, robustness, and adaptability needed for scientific and operational use.</p>
-      <p class="home-project__related"><strong>Related work:</strong> <a href="https://arxiv.org/abs/2508.01426">UniExtreme</a> · <a href="https://www.vldb.org/pvldb/vol18/p2149-han.pdf">CompactST</a> · <a href="https://www.vldb.org/pvldb/vol17/p1081-han.pdf">BigST</a> · <a href="https://proceedings.mlr.press/v235/zhang24bw.html">t-PatchGNN</a></p>
-    </div>
-  </article>
+  {% for theme in site.data.research.themes %}
+    <article class="home-project" id="{{ theme.id }}">
+      <div class="home-project__identity">
+        <img class="home-project__visual" src="{{ site.baseurl }}{{ theme.image }}" alt="" loading="lazy">
+        <h3 class="home-project__theme">{{ theme.title }}</h3>
+      </div>
+      <div class="home-project__content">
+        <p class="home-project__question">{{ theme.description }}</p>
+        <p class="home-project__related"><strong>Related work:</strong>
+          {% for paper in theme.related %}<a href="{{ paper.url | escape }}">{{ paper.title }}</a>{% unless forloop.last %} · {% endunless %}{% endfor %}
+        </p>
+      </div>
+    </article>
+  {% endfor %}
 </div>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -9,50 +9,44 @@ redirect_from:
   - /about.html
 ---
 
+{% assign profile = site.data.profile %}
+{% assign home = site.data.home %}
+
 <section class="home-intro" aria-labelledby="home-name">
   <div class="home-intro__copy">
-    <h1 id="home-name">Hao Liu</h1>
+    <h1 id="home-name">{{ profile.name }}</h1>
 
-    <p class="home-bio">I am an Associate Professor in the Artificial Intelligence Thrust at The Hong Kong University of Science and Technology (Guangzhou), and an affiliated faculty member at HKUST. Before joining HKUST(GZ), I was a Research Scientist at Baidu Research.</p>
+    <p class="home-bio">{{ profile.bio }}</p>
 
     <nav class="home-links" aria-label="Profile links">
-      <a class="home-links__internal" href="#join-us">Join Us</a>
-      <a href="https://scholar.google.com/citations?user=66KKZR4AAAAJ&amp;hl=en">Google Scholar</a>
-      <a href="https://github.com/usail-hkust">GitHub</a>
-      <a href="mailto:liuh@ust.hk">Email</a>
+      {% for link in profile.links %}
+        <a{% if link.internal %} class="home-links__internal"{% endif %} href="{{ link.url | escape }}">{{ link.label }}</a>
+      {% endfor %}
     </nav>
   </div>
 
   <figure class="home-portrait">
-    <img src="{{ site.baseurl }}/images/haoliu.jpg" alt="Portrait of Hao Liu">
+    <img src="{{ site.baseurl }}{{ profile.portrait.src }}" alt="{{ profile.portrait.alt }}">
   </figure>
 </section>
 
 <section class="home-overview" id="research" aria-labelledby="research-heading">
   <header class="home-overview__header">
-    <h2 id="research-heading">Building agentic systems for complex digital and physical worlds.</h2>
-    <p>My recent interest spans agentic data science, scientific discovery, and decision-making in dynamic real-world systems.</p>
+    <h2 id="research-heading">{{ home.research.heading }}</h2>
+    <p>{{ home.research.lead }}</p>
   </header>
 
   <div class="home-questions home-questions--overview" aria-label="Core research capabilities">
-    <article class="home-question">
-      <span class="home-question__number">01</span>
-      <h3>Understand complex worlds</h3>
-      <p>Learn transferable representations of complex, evolving environments across scales and domains.</p>
-    </article>
-    <article class="home-question">
-      <span class="home-question__number">02</span>
-      <h3>Make grounded decisions</h3>
-      <p>Reason with evidence, tools, collaborators, and physical constraints to act reliably in real-world environments.</p>
-    </article>
-    <article class="home-question">
-      <span class="home-question__number">03</span>
-      <h3>Learn through interaction</h3>
-      <p>Improve analytical and scientific workflows through execution feedback, reusable skills, and accumulated experience.</p>
-    </article>
+    {% for capability in home.research.capabilities %}
+      <article class="home-question">
+        <span class="home-question__number">{{ capability.number }}</span>
+        <h3>{{ capability.title }}</h3>
+        <p>{{ capability.description }}</p>
+      </article>
+    {% endfor %}
   </div>
 
-  <p class="home-section__footer-link home-section__footer-link--research"><a href="{{ site.baseurl }}/research/">Explore research themes and related work →</a></p>
+  <p class="home-section__footer-link home-section__footer-link--research"><a href="{{ site.baseurl }}{{ home.research.link.url }}">{{ home.research.link.label }}</a></p>
 </section>
 
 <section class="home-section" aria-labelledby="updates-heading">
@@ -60,49 +54,22 @@ redirect_from:
     <h2 class="home-section__eyebrow" id="updates-heading">Recent updates</h2>
   </header>
 
-  <ul class="home-updates">
-    <li class="home-update">
-      <time datetime="2026-07">Jul 2026</time>
-      <p>Call for papers: the <a href="https://link.springer.com/collections/fhbghibigc">Frontiers of AI and Data Science Competitions</a> special issue in <strong>Frontiers of Computer Science</strong> is now open for submissions.</p>
-    </li>
-    <li class="home-update">
-      <time datetime="2026-05">May 2026</time>
-      <p>New papers at <strong>KDD 2026</strong> on <a href="{{ site.baseurl }}/publications/full/">autonomous data science, travel agents, extreme-weather forecasting, and flood forecasting</a>.</p>
-    </li>
-    <li class="home-update">
-      <time datetime="2026-01">Jan 2026</time>
-      <p>New work at <strong>ICLR 2026</strong> and <strong>The Web Conference 2026</strong> on <a href="https://openreview.net/forum?id=kZHSvETWdi">multimodal scientific discovery</a>, <a href="https://arxiv.org/abs/2503.11739">cooperative urban agents</a>, and <a href="https://arxiv.org/abs/2505.17572">spatiotemporal reasoning</a>.</p>
-    </li>
-    <li class="home-update">
-      <time datetime="2025-09">Sep 2025</time>
-      <p>Three papers were accepted to <strong>NeurIPS 2025</strong>, exploring agentic scientific discovery, mathematical modeling agents, and test-time reasoning.</p>
-    </li>
-    <li class="home-update">
-      <time datetime="2025-08">Aug 2025</time>
-      <p><a href="https://arxiv.org/abs/2312.16044">LLMLight</a> received the <a href="https://kdd2025.kdd.org/awards/">KDD 2025 Audience Appreciation Award</a>.</p>
-    </li>
-  </ul>
+  {% include news-list.html featured_only=true use_summary=true limit=5 %}
   <p class="home-news-link"><a href="{{ site.baseurl }}/news/">Older news →</a></p>
 </section>
 
 <section class="home-section" id="join-us" aria-labelledby="join-us-heading">
   <header class="home-section__header">
-    <p class="home-section__eyebrow">Join us</p>
-    <h2 class="home-section__title" id="join-us-heading">Work with us.</h2>
+    <p class="home-section__eyebrow">{{ home.join.eyebrow }}</p>
+    <h2 class="home-section__title" id="join-us-heading">{{ home.join.title }}</h2>
   </header>
 
   <div class="home-join">
-    <article>
-      <h3>Postdoc and PhD students</h3>
-      <p>Postdoctoral / Research Associate positions are available. Prospective Ph.D. students whose interests align with our research are also welcome. Please email your CV and representative work to <a href="mailto:liuh@ust.hk">liuh@ust.hk</a>.</p>
-    </article>
-    <article>
-      <h3>RBM students</h3>
-      <p>Please apply directly through the <a href="https://pgoas.hkust-gz.edu.cn/">HKUST(GZ) Online Admission System</a>. After receiving an offer, you are welcome to contact me to discuss research fit; joining the group as an RA before making a final decision is encouraged. Please read the <a href="{{ site.baseurl }}/files/MPhil_Guideline.pdf">Guidelines &amp; Expectations</a>.</p>
-    </article>
-    <article>
-      <h3>RAs, interns, and visiting students</h3>
-      <p>We welcome applications year-round from students who can commit for at least six months. We provide a stipend, computing resources, and close research mentorship. Please email your CV, availability, and a brief description of your research interests to <a href="mailto:liuh@ust.hk">liuh@ust.hk</a>.</p>
-    </article>
+    {% for opportunity in home.join.opportunities %}
+      <article>
+        <h3>{{ opportunity.title }}</h3>
+        <p>{% include inline-markdown.html content=opportunity.content %}</p>
+      </article>
+    {% endfor %}
   </div>
 </section>

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -11,30 +11,6 @@ author_profile: false
 </header>
 
 <section class="news-archive" aria-label="News archive">
-  <ul class="home-updates home-updates--archive">
-    <li class="home-update"><time datetime="2026-07">Jul 2026</time><p>Call for papers: the <a href="https://link.springer.com/collections/fhbghibigc">Frontiers of AI and Data Science Competitions</a> special issue in <strong>Frontiers of Computer Science</strong> is now open for submissions.</p></li>
-    <li class="home-update"><time datetime="2026-05-18">May 2026</time><p>New papers at <strong>KDD 2026</strong> and <strong>ICML 2026</strong> on autonomous data science, travel agents, efficient agent reasoning, and flood forecasting.</p></li>
-    <li class="home-update"><time datetime="2026">2026</time><p>New work at <strong>ICLR 2026</strong> and <strong>The Web Conference 2026</strong> on <a href="https://openreview.net/forum?id=kZHSvETWdi">multimodal scientific discovery</a>, <a href="https://arxiv.org/abs/2503.11739">cooperative urban agents</a>, and <a href="https://arxiv.org/abs/2505.17572">spatiotemporal reasoning</a>.</p></li>
-    <li class="home-update"><time datetime="2025-11-25">Nov 2025</time><p>New papers at <strong>KDD 2026</strong> and <strong>AAAI 2026</strong> on extreme-weather forecasting, subseasonal-to-seasonal weather forecasting, travel-time estimation, and recommendation.</p></li>
-    <li class="home-update"><time datetime="2025-09-25">Sep 2025</time><p>Three papers were accepted to <strong>NeurIPS 2025</strong>, exploring agentic scientific discovery, mathematical modeling agents, and test-time reasoning.</p></li>
-    <li class="home-update"><time datetime="2025-08-05">Aug 2025</time><p><a href="https://arxiv.org/abs/2312.16044">LLMLight</a> received the <a href="https://kdd2025.kdd.org/awards/">KDD 2025 Audience Appreciation Award</a>.</p></li>
-    <li class="home-update"><time datetime="2025-06-01">Jun 2025</time><p>Congratulations to Jindong Han on joining Shandong University as an Associate Professor.</p></li>
-    <li class="home-update"><time datetime="2025-05-31">May 2025</time><p>Received an Outstanding Reviewer recognition from <strong>KDD 2025</strong>.</p></li>
-    <li class="home-update"><time datetime="2025-05-20">May 2025</time><p>Five papers were accepted to <strong>KDD 2025</strong> on time-series modeling, nuclear-radiation forecasting, ride-hailing agents, and scientific retrieval.</p></li>
-    <li class="home-update"><time datetime="2025-04-30">Apr 2025</time><p>One paper on language-model-empowered spatiotemporal forecasting was accepted to <strong>IJCAI 2025</strong>.</p></li>
-    <li class="home-update"><time datetime="2025-04-25">Apr 2025</time><p>Congratulations to Weijia Zhang on receiving the 2025 Baidu Scholarship.</p></li>
-    <li class="home-update"><time datetime="2025-04-15">Apr 2025</time><p>The LLMLight team received a Special Award and Gold Medal at the International Exhibition of Inventions Geneva 2025.</p></li>
-    <li class="home-update"><time datetime="2025-03-16">Mar 2025</time><p>Our work on compact pre-trained spatiotemporal predictive models was accepted to <strong>VLDB 2025</strong>.</p></li>
-    <li class="home-update"><time datetime="2025-01-23">Jan 2025</time><p>Three papers were accepted to <strong>ICLR 2025</strong> and <strong>The Web Conference 2025</strong>, including a spotlight on retrieval utility measurement for RAG.</p></li>
-    <li class="home-update"><time datetime="2024-12-19">Dec 2024</time><p>Our group received reviewer recognitions from <strong>KDD 2025</strong>.</p></li>
-    <li class="home-update"><time datetime="2024-11-20">Nov 2024</time><p>Three papers were accepted to <strong>KDD 2025</strong> on traffic-control agents, automated spatiotemporal forecasting, and graph adaptation.</p></li>
-    <li class="home-update"><time datetime="2024-09-26">Sep 2024</time><p>Two papers were accepted to <strong>NeurIPS 2024</strong> on urban knowledge-graph agents and LLM jailbreak evaluation.</p></li>
-    <li class="home-update"><time datetime="2024-09-20">Sep 2024</time><p>Our IEEE recommended practice for applying knowledge graphs to talent services was formally published.</p></li>
-    <li class="home-update"><time datetime="2024-09-13">Sep 2024</time><p>Started serving as an Associate Editor of <strong>IEEE Transactions on Big Data</strong>.</p></li>
-    <li class="home-update"><time datetime="2024-08-30">Aug 2024</time><p><a href="https://www.vldb.org/pvldb/vol17/p1081-han.pdf">BigST</a> received a <strong>VLDB 2024 Best Research Paper Nomination</strong>.</p></li>
-    <li class="home-update"><time datetime="2024-08-27">Aug 2024</time><p>We presented a tutorial on <a href="https://github.com/usail-hkust/Awesome-Urban-Foundation-Models">Urban Foundation Models</a> at <strong>KDD 2024</strong>.</p></li>
-    <li class="home-update"><time datetime="2024-05-17">May 2024</time><p>Three papers were accepted to <strong>KDD 2024</strong> on congestion prediction, federated graph learning, and irregular traffic forecasting.</p></li>
-    <li class="home-update"><time datetime="2024-05-01">May 2024</time><p>Our work on irregular multivariate time-series forecasting was accepted to <strong>ICML 2024</strong>.</p></li>
-  </ul>
+  {% include news-list.html archive=true %}
   <p class="home-section__footer-link"><a href="{{ site.baseurl }}/">← Back to homepage</a></p>
 </section>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -6,30 +6,30 @@ excerpt: "Research on agentic systems for complex digital and physical worlds."
 author_profile: false
 ---
 
+{% assign research = site.data.research %}
+
 <header class="page-heading page-heading--with-lead">
   <h1>Research</h1>
-  <p>We study agentic intelligence across digital and physical worlds: systems that understand complex environments, make grounded decisions, and learn from the consequences of action.</p>
+  <p>{{ research.lead }}</p>
 </header>
 
 <figure class="research-framework">
   <picture>
-    <source media="(max-width: 560px)" srcset="{{ site.baseurl }}/images/research/research-overview-mobile.svg">
-    <img src="{{ site.baseurl }}/images/research/research-overview.svg" alt="Research framework connecting models of dynamic worlds, grounded physical agents, and agentic data scientists around agentic intelligence across digital-physical space.">
+    <source media="(max-width: 560px)" srcset="{{ site.baseurl }}{{ research.framework.mobile_image }}">
+    <img src="{{ site.baseurl }}{{ research.framework.desktop_image }}" alt="{{ research.framework.alt }}">
   </picture>
-  <figcaption>The three themes are mutually reinforcing: data-science agents build and interrogate world models, models guide physical action, and interaction returns evidence that improves both models and workflows.</figcaption>
+  <figcaption>{{ research.framework.caption }}</figcaption>
 </figure>
 
 <section class="research-perspectives" aria-labelledby="research-perspectives-heading">
   <h2 id="research-perspectives-heading">Surveys &amp; perspectives</h2>
   <ul>
-    <li><a href="http://www.techrxiv.org/doi/full/10.36227/techrxiv.174953071.19189612/v1">Foundation Models for Scientific Discovery: From Paradigm Enhancement to Paradigm Transition</a></li>
-    <li><a href="https://github.com/usail-hkust/Awesome-Urban-Foundation-Models">Urban Foundation Models: A Survey</a></li>
-    <li><a href="https://arxiv.org/abs/2507.00914">Large Language Model Powered Intelligent Urban Agents: Concepts, Capabilities, and Applications</a></li>
+    {% for paper in research.perspectives %}<li><a href="{{ paper.url | escape }}">{{ paper.title }}</a></li>{% endfor %}
   </ul>
 </section>
 
 <section class="research-page__body" aria-label="Research themes and related work">
   {% include selected-research-theme.html %}
 
-  <p class="home-section__footer-link"><a href="{{ site.baseurl }}/publications/full/">View full publication list →</a></p>
+  <p class="home-section__footer-link"><a href="{{ site.baseurl }}{{ research.full_publications.url }}">{{ research.full_publications.label }}</a></p>
 </section>

--- a/_pages/services.md
+++ b/_pages/services.md
@@ -16,16 +16,9 @@ author_profile: false
   </header>
 
   <ul class="service-list">
-    <li><a href="https://www.computer.org/csdl/journal/bd">IEEE Transactions on Big Data</a><span>Associate Editor</span></li>
-    <li><a href="https://www.nature.com/npjai/editors">npj Artificial Intelligence</a><span>Editorial Board Member</span></li>
-    <li><a href="https://jcst.ict.ac.cn/">Journal of Computer Science and Technology</a><span>Young Scientist Editor</span></li>
-    <li><a href="https://dl.acm.org/journal/tist">ACM Transactions on Intelligent Systems and Technology</a><span>Guest Editor</span></li>
-    <li><a href="https://link.springer.com/journal/11704">Frontiers of Computer Science</a><span>Guest Editor</span></li>
-    <li><a href="https://link.springer.com/referencework/10.1007/978-0-387-35973-1">Encyclopedia of GIS</a><span>Field Editor</span></li>
-    <li><a href="https://2025.ijcai.org/">IJCAI 2025</a><span>Competition Chair</span></li>
-    <li><a href="https://vldb.org/2024/">VLDB 2024</a><span>Local Chair</span></li>
-    <li><strong>IEEE P3154 Standard Working Group</strong><span>Secretary</span></li>
-    <li><strong>KDD Cup 2019 · Regular ML Track</strong><span>Co-organizer</span></li>
+    {% for service in site.data.services.editorial_and_organizational %}
+      <li>{% if service.url %}<a href="{{ service.url | escape }}">{{ service.organization }}</a>{% else %}<strong>{{ service.organization }}</strong>{% endif %}<span>{{ service.role }}</span></li>
+    {% endfor %}
   </ul>
 </section>
 
@@ -35,16 +28,9 @@ author_profile: false
   </header>
 
   <div class="service-grid">
-    <article><h3>KDD</h3><p>2019–2026</p></article>
-    <article><h3>ACL Rolling Review</h3><p>2023–2026</p></article>
-    <article><h3>IJCAI</h3><p>2021–2024</p></article>
-    <article><h3>AAAI</h3><p>2020–2026</p></article>
-    <article><h3>NeurIPS</h3><p>2023–2026</p></article>
-    <article><h3>ICLR</h3><p>2023–2026</p></article>
-    <article><h3>The Web Conference</h3><p>2023</p></article>
-    <article><h3>ICDM</h3><p>2023–2025</p></article>
-    <article><h3>SDM</h3><p>2021, 2023</p></article>
-    <article><h3>ECAI</h3><p>2025</p></article>
+    {% for conference in site.data.services.conferences %}
+      <article><h3>{{ conference.name }}</h3><p>{{ conference.years }}</p></article>
+    {% endfor %}
   </div>
 </section>
 
@@ -54,13 +40,6 @@ author_profile: false
   </header>
 
   <ul class="journal-list">
-    <li>IEEE Transactions on Knowledge and Data Engineering</li>
-    <li>ACM Transactions on Knowledge Discovery from Data</li>
-    <li>ACM Transactions on Intelligent Systems and Technology</li>
-    <li>Data &amp; Knowledge Engineering</li>
-    <li>IEEE Transactions on Big Data</li>
-    <li>IEEE Transactions on Cybernetics</li>
-    <li>Scientific Reports</li>
-    <li>Transportation Research Part C</li>
+    {% for journal in site.data.services.journals %}<li>{{ journal }}</li>{% endfor %}
   </ul>
 </section>

--- a/_pages/students.md
+++ b/_pages/students.md
@@ -16,18 +16,12 @@ author_profile: false
   </header>
 
   <ul class="achievement-list achievement-list--flat">
-    <li><strong>Tengfei Lyu</strong><span>HKUST(GZ) AI Thrust 2026 Best Research Award</span></li>
-    <li><strong>Yansong Ning</strong><span>HKUST(GZ) AI Thrust 2026 Rising Star Award</span></li>
-    <li><strong>Fan Liu</strong><span>2026 Lizhi Scholarship</span></li>
-    <li><strong>Fan Liu</strong><span>HKUST(GZ) AI Thrust 2025 Best Research Award</span></li>
-    <li><strong>Weijia Zhang</strong><span>2025 Baidu Scholarship</span></li>
-    <li><strong>Siqi Lai</strong><span><a href="{{ site.baseurl }}/images/trophy.jpg">Special Award of International Exhibition of Inventions Geneva 2025</a></span></li>
-    <li><strong>Siqi Lai</strong><span><a href="https://kdd2025.kdd.org/awards/">KDD 2025 Audience Appreciation Award</a></span></li>
-    <li><strong>Jindong Han</strong><span>2025 National Young Talent Plan</span></li>
-    <li><strong>Jindong Han</strong><span>HKUST AIS 2024 Best Research Award</span></li>
-    <li><strong>Jindong Han</strong><span>VLDB 2024 Best Research Paper Nomination Award</span></li>
-    <li><strong>Fan Liu</strong><span>HKUST(GZ) AI Thrust 2024 Rising Star Award</span></li>
-    <li><strong>Weijia Zhang</strong><span>HKUST(GZ) AI Thrust 2023 Best Research Award</span></li>
+    {% for achievement in site.data.students.achievements %}
+      <li>
+        <strong>{{ achievement.name }}</strong>
+        <span>{% if achievement.url %}<a href="{{ achievement.url | escape }}">{{ achievement.award }}</a>{% else %}{{ achievement.award }}{% endif %}</span>
+      </li>
+    {% endfor %}
   </ul>
 </section>
 
@@ -37,32 +31,16 @@ author_profile: false
   </header>
 
   <div class="people-groups">
-  <ul class="people-list people-group">
-    <li><strong>Weijia Zhang</strong><span>Ph.D., 2026 → Ant Group (Talent Plan)</span></li>
-    <li><strong>Ruiqian Han</strong><span>M.Phil., 2026 → DiDi Chuxing</span></li>
-    <li><strong>Hao Wang</strong><span>M.Phil., 2026 → Ph.D. student, The Hong Kong Polytechnic University</span></li>
-    <li><strong>Yuxuan Fan</strong><span>M.Phil., 2026 → Ph.D. student, Nanyang Technological University</span></li>
-    <li><strong>Jindong Han</strong><span>Ph.D., 2025 → Professor, Shandong University</span></li>
-    <li><strong>Zhao Xu</strong><span>M.Phil., 2025 → Ph.D. student, UCLA</span></li>
-    <li><strong>Tianrui Song</strong><span>M.Phil., 2025 → Master's student, King's College London</span></li>
-    <li><strong>Wenshuo Chao</strong><span>M.Phil., 2024 → Quant Researcher @ Private Fund</span></li>
-    <li><strong>Ziyang Wu</strong><span>M.Phil., 2024 → China Grid</span></li>
-    <li><strong>Ruohong Liu</strong><span>M.Phil., 2024 → Ph.D. student, University of Oxford</span></li>
-    <li><strong>Qingyan Zhu</strong><span>M.Phil., 2022 → NIO Inc.</span></li>
-  </ul>
+    <ul class="people-list people-group">
+      {% for person in site.data.students.alumni.students %}
+        <li><strong>{{ person.name }}</strong><span>{{ person.degree }}, {{ person.year }} → {{ person.destination }}</span></li>
+      {% endfor %}
+    </ul>
 
-  <ul class="people-list people-group people-group--assistants">
-    <li><strong>Xiaolong Jin</strong><span>Research Assistant · Undergraduate, USTC → Ph.D. student, Purdue University</span></li>
-    <li><strong>Weilin Lin</strong><span>Research Assistant · M.Sc., City University of Hong Kong → Ph.D. student, HKUST(GZ)</span></li>
-    <li><strong>Zixuan Weng</strong><span>Research Assistant · Undergraduate, Beijing Jiaotong University → Ph.D. student, Georgia Tech</span></li>
-    <li><strong>Can Chen</strong><span>Intern · Undergraduate, USTC → Ph.D. student, McGill University</span></li>
-    <li><strong>Wei Fan</strong><span>Intern · Ph.D., University of Central Florida → Lecturer, University of Auckland</span></li>
-    <li><strong>Qingyu Guo</strong><span>Intern · Ph.D. student, HKUST → Tencent</span></li>
-    <li><strong>Carter Blum</strong><span>Intern · Master's student, University of Minnesota → Bloomberg</span></li>
-    <li><strong>Ying Xu</strong><span>Intern · Ph.D. student, National University of Defense Technology</span></li>
-    <li><strong>Pengfei Wang</strong><span>Intern · Ph.D., Chinese Academy of Sciences → Associate Researcher, Chinese Academy of Sciences</span></li>
-    <li><strong>Zixuan Yuan</strong><span>Intern · Ph.D., Rutgers University → Assistant Professor, HKUST(GZ)</span></li>
-    <li><strong>Ting Li</strong><span>Intern · Master's student, National University of Defense Technology → JD Digits</span></li>
-  </ul>
+    <ul class="people-list people-group people-group--assistants">
+      {% for person in site.data.students.alumni.assistants %}
+        <li><strong>{{ person.name }}</strong><span>{{ person.role }} · {{ person.background }}{% if person.destination %} → {{ person.destination }}{% endif %}</span></li>
+      {% endfor %}
+    </ul>
   </div>
 </section>

--- a/_pages/talks.md
+++ b/_pages/talks.md
@@ -3,10 +3,12 @@ title: "Talks and Presentations"
 permalink: /talks/
 author_profile: true
 ---
-* **Next Generation Smart Transportation: Research and Applications**. Invited Talk at 2020 China
-Collegiate Computing Contest - Artificial Intelligence Innovation Contest. *2020-08-28*.
-* **Hydra: A Personalized and Context-Aware Multi-Modal Transportation Recommendation System**. Oral Presentation at KDD 2019, Alaska, USA. *2019-08-06*.
-* **Baidu’s Initiative in Creating the Future of Intelligent Transportation**. Invited talk at [World AI Summit Americas](https://americas.worldsummit.ai/), Montreal, Canada. *2019-04-11*.
-* **Baidu AI**. Recruitment talk at Tsinghua University, Beijing, China. *2019-03-18*.
-* **Baidu Brain 3.0**. Invited talk at University of Macau, Macau, China. *2019-02-15*.
-* **Joint Representation Learning for Multi-Modal Transportation Recommendation**. Oral Presentation at AAAI 2019, Hawaii, USA. *2019-01-29*.
+<ul class="talk-list">
+  {% for talk in site.data.talks.items %}
+    <li>
+      <strong>{{ talk.title }}</strong>. {{ talk.format }} at
+      {% if talk.venue_url %}<a href="{{ talk.venue_url }}">{{ talk.venue }}</a>{% else %}{{ talk.venue }}{% endif %}{% if talk.location %}, {{ talk.location }}{% endif %}.
+      <em>{{ talk.date }}</em>.
+    </li>
+  {% endfor %}
+</ul>

--- a/_pages/teaching.md
+++ b/_pages/teaching.md
@@ -15,16 +15,7 @@ author_profile: false
     <h2 id="current-courses-heading">Current Courses</h2>
   </header>
 
-  <ul class="course-history course-history--current">
-    <li>
-      <time>2026 Fall</time>
-      <div><strong>AIAA 3111</strong><span>Introduction to Data Mining</span></div>
-    </li>
-    <li>
-      <time>2026 Fall</time>
-      <div><strong>UCUG 1002</strong><span>Artificial Intelligence General Education</span></div>
-    </li>
-  </ul>
+  {% include course-list.html courses=site.data.teaching.current current=true %}
 </section>
 
 <section class="academic-section academic-section--compact" aria-labelledby="past-courses-heading">
@@ -32,38 +23,5 @@ author_profile: false
     <h2 id="past-courses-heading">Past Courses</h2>
   </header>
 
-  <ul class="course-history">
-    <li>
-      <time>2026 Spring</time>
-      <div><strong>UCMP 6010</strong><span>Cross-disciplinary Research Methods I</span></div>
-    </li>
-    <li>
-      <time>2025 Fall</time>
-      <div><strong>AIAA 3111</strong><span>Introduction to Data Mining</span></div>
-    </li>
-    <li>
-      <time>2025 Fall</time>
-      <div><strong>UCMP 6010</strong><span>Cross-disciplinary Research Methods I</span></div>
-    </li>
-    <li>
-      <time>2025 Spring</time>
-      <div><strong>UCMP 6010</strong><span>Cross-disciplinary Research Methods I</span></div>
-    </li>
-    <li>
-      <time>2024 Fall</time>
-      <div><strong>UFUG 1601</strong><span>Introduction to Computer Science</span></div>
-    </li>
-    <li>
-      <time>2024 Fall</time>
-      <div><strong>UCMP 6010</strong><span>Cross-disciplinary Research Methods I</span></div>
-    </li>
-    <li>
-      <time>2023 Fall</time>
-      <div><strong>AIAA 5028</strong><span>Machine Learning on Graphs</span></div>
-    </li>
-    <li>
-      <time>2022 Fall</time>
-      <div><strong>AIAA 5028</strong><span>Machine Learning on Graphs</span></div>
-    </li>
-  </ul>
+  {% include course-list.html courses=site.data.teaching.past %}
 </section>

--- a/scripts/validate_content.rb
+++ b/scripts/validate_content.rb
@@ -1,0 +1,226 @@
+#!/usr/bin/env ruby
+
+require "date"
+require "yaml"
+
+ROOT = File.expand_path("..", __dir__)
+DATA_DIR = File.join(ROOT, "_data")
+
+errors = []
+
+def load_data(name)
+  YAML.safe_load(
+    File.read(File.join(DATA_DIR, "#{name}.yml")),
+    permitted_classes: [Date, Time],
+    aliases: true
+  )
+end
+
+def require_fields(item, fields, context, errors)
+  fields.each do |field|
+    value = item[field]
+    errors << "#{context}: missing #{field}" if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+  end
+end
+
+def validate_url(url, context, errors)
+  unless url.match?(%r{\A(?:https?://|mailto:|#|/)})
+    errors << "#{context}: unsupported URL #{url}"
+    return
+  end
+
+  return unless url.start_with?("/") && File.extname(url.split(/[?#]/, 2).first) != ""
+
+  local_path = File.join(ROOT, url.split(/[?#]/, 2).first.delete_prefix("/"))
+  errors << "#{context}: local target not found at #{url}" unless File.file?(local_path)
+end
+
+def validate_links_in_markdown(content, context, errors)
+  content.to_s.scan(/\[[^\]]+\]\(([^)]+)\)/).flatten.each do |url|
+    validate_url(url, context, errors)
+  end
+end
+
+def normalized_date(value)
+  string = value.to_s
+  case string
+  when /\A\d{4}\z/ then Date.iso8601("#{string}-01-01")
+  when /\A\d{4}-\d{2}\z/ then Date.iso8601("#{string}-01")
+  else Date.iso8601(string)
+  end
+end
+
+profile = load_data("profile")
+require_fields(profile, %w[name affiliation bio portrait links footer_links], "profile", errors)
+require_fields(profile.fetch("portrait", {}), %w[src alt], "profile.portrait", errors)
+validate_url(profile.dig("portrait", "src"), "profile.portrait", errors) if profile.dig("portrait", "src")
+
+site_config = YAML.safe_load(File.read(File.join(ROOT, "_config.yml")), aliases: true)
+errors << "profile.name: does not match _config.yml name" unless profile["name"] == site_config["name"]
+errors << "profile.name: does not match _config.yml author name" unless profile["name"] == site_config.dig("author", "name")
+portrait_filename = File.basename(profile.dig("portrait", "src").to_s)
+errors << "profile.portrait: does not match _config.yml author avatar" unless portrait_filename == site_config.dig("author", "avatar")
+
+%w[links footer_links].each do |section|
+  Array(profile[section]).each_with_index do |link, index|
+    context = "profile.#{section}[#{index}]"
+    require_fields(link, %w[label url], context, errors)
+    validate_url(link["url"], context, errors) if link["url"]
+  end
+  labels = Array(profile[section]).map { |link| link["label"] }
+  errors << "profile.#{section}: duplicate labels" unless labels.uniq.size == labels.size
+end
+
+home = load_data("home")
+research_summary = home.fetch("research", {})
+join = home.fetch("join", {})
+require_fields(research_summary, %w[heading lead capabilities link], "home.research", errors)
+capabilities = Array(research_summary["capabilities"])
+errors << "home.research: expected three capabilities" unless capabilities.size == 3
+capabilities.each_with_index do |capability, index|
+  require_fields(capability, %w[number title description], "home.research.capabilities[#{index}]", errors)
+end
+numbers = capabilities.map { |capability| capability["number"] }
+errors << "home.research: duplicate capability numbers" unless numbers.uniq.size == numbers.size
+require_fields(research_summary.fetch("link", {}), %w[label url], "home.research.link", errors)
+validate_url(research_summary.dig("link", "url"), "home.research.link", errors) if research_summary.dig("link", "url")
+
+require_fields(join, %w[eyebrow title opportunities], "home.join", errors)
+opportunities = Array(join["opportunities"])
+errors << "home.join: expected at least one opportunity" if opportunities.empty?
+opportunities.each_with_index do |opportunity, index|
+  context = "home.join.opportunities[#{index}]"
+  require_fields(opportunity, %w[title content], context, errors)
+  validate_links_in_markdown(opportunity["content"], context, errors)
+end
+
+news = load_data("news").fetch("items", [])
+errors << "news: no items" if news.empty?
+news_dates = []
+news.each_with_index do |item, index|
+  context = "news.items[#{index}]"
+  require_fields(item, %w[date display content], context, errors)
+  begin
+    news_dates << normalized_date(item["date"])
+  rescue Date::Error
+    errors << "#{context}: invalid date #{item['date']}"
+  end
+  validate_links_in_markdown(item["content"], context, errors)
+  validate_links_in_markdown(item["summary"], "#{context}.summary", errors) if item["summary"]
+end
+errors << "news: items are not in reverse chronological order" unless news_dates == news_dates.sort.reverse
+news_keys = news.map { |item| [item["date"].to_s, item["content"]] }
+errors << "news: duplicate entries" unless news_keys.uniq.size == news_keys.size
+errors << "news: homepage requires at least five featured items" if news.count { |item| item["featured"] } < 5
+
+teaching = load_data("teaching")
+course_keys = []
+%w[current past].each do |section|
+  courses = Array(teaching[section])
+  errors << "teaching.#{section}: no courses" if courses.empty?
+  courses.each_with_index do |course, index|
+    context = "teaching.#{section}[#{index}]"
+    require_fields(course, %w[term code title], context, errors)
+    errors << "#{context}: invalid term #{course['term']}" unless course["term"].to_s.match?(/\A\d{4} (?:Spring|Summer|Fall|Winter)\z/)
+    course_keys << [course["term"], course["code"]]
+  end
+end
+errors << "teaching: duplicate term and course-code pairs" unless course_keys.uniq.size == course_keys.size
+
+students = load_data("students")
+achievements = Array(students["achievements"])
+achievement_years = achievements.map { |achievement| achievement["year"].to_i }
+errors << "students.achievements: not ordered by year" unless achievement_years == achievement_years.sort.reverse
+achievements.each_with_index do |achievement, index|
+  context = "students.achievements[#{index}]"
+  require_fields(achievement, %w[name year award], context, errors)
+  validate_url(achievement["url"], context, errors) if achievement["url"]
+end
+
+alumni = students.fetch("alumni", {})
+student_alumni = Array(alumni["students"])
+assistant_alumni = Array(alumni["assistants"])
+student_alumni.each_with_index do |person, index|
+  require_fields(person, %w[name degree year destination], "students.alumni.students[#{index}]", errors)
+end
+years = student_alumni.map { |person| person["year"].to_i }
+errors << "students.alumni.students: not ordered by year" unless years == years.sort.reverse
+assistant_alumni.each_with_index do |person, index|
+  require_fields(person, %w[name role background], "students.alumni.assistants[#{index}]", errors)
+end
+alumni_names = (student_alumni + assistant_alumni).map { |person| person["name"] }
+errors << "students.alumni: duplicate people" unless alumni_names.uniq.size == alumni_names.size
+
+services = load_data("services")
+editorial = Array(services["editorial_and_organizational"])
+conferences = Array(services["conferences"])
+journals = Array(services["journals"])
+errors << "services.editorial_and_organizational: no entries" if editorial.empty?
+errors << "services.conferences: no entries" if conferences.empty?
+errors << "services.journals: no entries" if journals.empty?
+editorial.each_with_index do |service, index|
+  context = "services.editorial_and_organizational[#{index}]"
+  require_fields(service, %w[organization role], context, errors)
+  validate_url(service["url"], context, errors) if service["url"]
+end
+conferences.each_with_index do |conference, index|
+  require_fields(conference, %w[name years], "services.conferences[#{index}]", errors)
+end
+errors << "services.journals: duplicate entries" unless journals.uniq.size == journals.size
+
+research = load_data("research")
+require_fields(research, %w[lead framework perspectives themes full_publications], "research", errors)
+framework = research.fetch("framework", {})
+require_fields(framework, %w[desktop_image mobile_image alt caption], "research.framework", errors)
+%w[desktop_image mobile_image].each do |field|
+  validate_url(framework[field], "research.framework.#{field}", errors) if framework[field]
+end
+
+Array(research["perspectives"]).each_with_index do |paper, index|
+  context = "research.perspectives[#{index}]"
+  require_fields(paper, %w[title url], context, errors)
+  validate_url(paper["url"], context, errors) if paper["url"]
+end
+
+themes = Array(research["themes"])
+errors << "research.themes: expected three themes" unless themes.size == 3
+themes.each_with_index do |theme, index|
+  context = "research.themes[#{index}]"
+  require_fields(theme, %w[id title image description related], context, errors)
+  errors << "#{context}: invalid id #{theme['id']}" unless theme["id"].to_s.match?(/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/)
+  validate_url(theme["image"], context, errors) if theme["image"]
+  errors << "#{context}: no related work" if Array(theme["related"]).empty?
+  Array(theme["related"]).each_with_index do |paper, paper_index|
+    paper_context = "#{context}.related[#{paper_index}]"
+    require_fields(paper, %w[title url], paper_context, errors)
+    validate_url(paper["url"], paper_context, errors) if paper["url"]
+  end
+end
+theme_ids = themes.map { |theme| theme["id"] }
+errors << "research.themes: duplicate IDs" unless theme_ids.uniq.size == theme_ids.size
+require_fields(research.fetch("full_publications", {}), %w[label url], "research.full_publications", errors)
+validate_url(research.dig("full_publications", "url"), "research.full_publications", errors) if research.dig("full_publications", "url")
+
+talks = load_data("talks").fetch("items", [])
+errors << "talks: no entries" if talks.empty?
+talk_dates = []
+talks.each_with_index do |talk, index|
+  context = "talks.items[#{index}]"
+  require_fields(talk, %w[title format venue date], context, errors)
+  validate_url(talk["venue_url"], context, errors) if talk["venue_url"]
+  begin
+    talk_dates << Date.iso8601(talk["date"].to_s)
+  rescue Date::Error
+    errors << "#{context}: invalid date #{talk['date']}"
+  end
+end
+errors << "talks: entries are not in reverse chronological order" unless talk_dates == talk_dates.sort.reverse
+talk_keys = talks.map { |talk| [talk["title"], talk["date"].to_s] }
+errors << "talks: duplicate entries" unless talk_keys.uniq.size == talk_keys.size
+
+unless errors.empty?
+  warn errors.map { |error| "- #{error}" }.join("\n")
+  exit 1
+end
+
+puts "Validated structured content: #{news.size} news items, #{course_keys.size} courses, #{achievements.size} achievements, #{alumni_names.size} alumni, #{editorial.size + conferences.size + journals.size} service entries, #{themes.size} research themes, and #{talks.size} talks."

--- a/scripts/validate_site.rb
+++ b/scripts/validate_site.rb
@@ -2,6 +2,9 @@
 
 require "pathname"
 require "uri"
+require "yaml"
+
+source_dir = Pathname.new(File.expand_path("..", __dir__))
 
 build_dir = Pathname.new(ARGV.fetch(0) do
   abort "Usage: ruby scripts/validate_site.rb BUILD_DIRECTORY"
@@ -23,6 +26,28 @@ core_pages = %w[
 ]
 
 errors = []
+
+def load_data(source_dir, name)
+  YAML.safe_load(source_dir.join("_data", "#{name}.yml").read, aliases: true)
+end
+
+def class_count(html, class_name)
+  html.scan(/class="[^"]*\b#{Regexp.escape(class_name)}\b[^"]*"/i).size
+end
+
+def container_child_counts(html, container_tag, class_name, child_tag)
+  pattern = /<#{container_tag}\b[^>]*class="[^"]*\b#{Regexp.escape(class_name)}\b[^"]*"[^>]*>(.*?)<\/#{container_tag}>/mi
+  html.scan(pattern).flatten.map { |contents| contents.scan(/<#{child_tag}\b/i).size }
+end
+
+def expect_count(actual, expected, context, errors)
+  errors << "#{context}: rendered #{actual.inspect}, expected #{expected.inspect}" unless actual == expected
+end
+
+def generated_html(build_dir, relative_path)
+  path = build_dir.join(relative_path)
+  path.file? ? path.read : ""
+end
 
 core_pages.each do |relative_path|
   page_path = build_dir.join(relative_path)
@@ -61,9 +86,48 @@ core_pages.each do |relative_path|
   end
 end
 
+# Cross-check the generated HTML against the structured content. This catches a
+# valid YAML edit that is accidentally omitted by a page template.
+home = load_data(source_dir, "home")
+news = load_data(source_dir, "news").fetch("items", [])
+teaching = load_data(source_dir, "teaching")
+students = load_data(source_dir, "students")
+services = load_data(source_dir, "services")
+research = load_data(source_dir, "research")
+talks = load_data(source_dir, "talks").fetch("items", [])
+
+index_html = generated_html(build_dir, "index.html")
+expect_count(class_count(index_html, "home-question"), home.dig("research", "capabilities").size, "index.html: research capabilities", errors)
+expect_count(class_count(index_html, "home-update"), [news.count { |item| item["featured"] }, 5].min, "index.html: featured news", errors)
+expect_count(container_child_counts(index_html, "div", "home-join", "article"), [home.dig("join", "opportunities").size], "index.html: Join Us opportunities", errors)
+
+news_html = generated_html(build_dir, "news/index.html")
+expect_count(class_count(news_html, "home-update"), news.size, "news/index.html: news entries", errors)
+
+teaching_html = generated_html(build_dir, "teaching/index.html")
+expected_course_counts = [teaching.fetch("current", []).size, teaching.fetch("past", []).size]
+expect_count(container_child_counts(teaching_html, "ul", "course-history", "li"), expected_course_counts, "teaching/index.html: course groups", errors)
+
+students_html = generated_html(build_dir, "students/index.html")
+expect_count(container_child_counts(students_html, "ul", "achievement-list", "li"), [students.fetch("achievements", []).size], "students/index.html: achievements", errors)
+expected_alumni_counts = [students.dig("alumni", "students").size, students.dig("alumni", "assistants").size]
+expect_count(container_child_counts(students_html, "ul", "people-list", "li"), expected_alumni_counts, "students/index.html: alumni groups", errors)
+
+services_html = generated_html(build_dir, "services/index.html")
+expect_count(container_child_counts(services_html, "ul", "service-list", "li"), [services.fetch("editorial_and_organizational", []).size], "services/index.html: editorial and organizational service", errors)
+expect_count(container_child_counts(services_html, "div", "service-grid", "article"), [services.fetch("conferences", []).size], "services/index.html: conference service", errors)
+expect_count(container_child_counts(services_html, "ul", "journal-list", "li"), [services.fetch("journals", []).size], "services/index.html: journal reviewing", errors)
+
+research_html = generated_html(build_dir, "research/index.html")
+expect_count(class_count(research_html, "home-project"), research.fetch("themes", []).size, "research/index.html: research themes", errors)
+expect_count(container_child_counts(research_html, "section", "research-perspectives", "li"), [research.fetch("perspectives", []).size], "research/index.html: surveys and perspectives", errors)
+
+talks_html = generated_html(build_dir, "talks/index.html")
+expect_count(container_child_counts(talks_html, "ul", "talk-list", "li"), [talks.size], "talks/index.html: talks", errors)
+
 unless errors.empty?
   warn errors.map { |error| "- #{error}" }.join("\n")
   exit 1
 end
 
-puts "Validated #{core_pages.size} core pages, their metadata, IDs, images, scripts, and internal links."
+puts "Validated #{core_pages.size} core pages, their metadata, IDs, images, scripts, internal links, and structured-content counts."


### PR DESCRIPTION
## Summary

- move frequently edited homepage, news, teaching, students, services, research, profile, and talks content into structured YAML data files
- render shared content through reusable Liquid includes while preserving the existing page structure and responsive styles
- add schema, ordering, local-asset, publication-resource, and rendered-count validation
- add a Chinese maintenance guide with copy-ready update examples
- run content and publication validation automatically on pushes and pull requests

## Why

The same content was previously embedded directly in several page templates, making routine updates error-prone and allowing the homepage and archive pages to drift. This change creates one canonical source for each frequently updated content domain while leaving stable long-form pages in Markdown.

## Validation

- production Jekyll build
- 23 news items, 10 courses, 12 achievements, 22 alumni, 28 service entries, 3 research themes, and 6 talks validated
- 112 full-list publications and 17 selected publications validated, including BibTeX, image, and code-link coverage
- 12 generated core pages checked for metadata, IDs, images, scripts, internal links, and data-to-render counts
- research SVGs validated with `xmllint`
- `npm audit`: 0 vulnerabilities
- browser regression across Home, Research, Publications, Students, Teaching, Services, Talks, and News
