### PR TITLE
Update recruiting and alumni details

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -81,6 +81,8 @@ past:
       destination: Assistant Professor, Example University
 ```
 
+学生 alumni 按学位分组：Ph.D. 在前，M.Phil. 在后；每组内部按毕业年份倒序排列。
+
 RA、intern 或 visiting student 加入 `alumni.assistants`：
 
 ```yaml

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -21,7 +21,7 @@ join:
   opportunities:
     - title: Postdoc and PhD students
       content: >-
-        Postdoctoral / Research Associate positions are available. Prospective Ph.D. students whose interests align with our research are also welcome. Please email your CV and representative work to [liuh@ust.hk](mailto:liuh@ust.hk).
+        We expect to have 1–2 postdoctoral openings and 3–4 Ph.D. openings for the Spring/Fall 2027 intake. Candidates whose interests align with our research are encouraged to apply. Postdoctoral applicants should email a CV, research statement, representative work, and preferred start date to [liuh@ust.hk](mailto:liuh@ust.hk). Prospective Ph.D. students should email a CV, transcripts, representative work, and intended intake; formal applications should also be submitted through the [HKUST(GZ) Online Admission System](https://pgoas.hkust-gz.edu.cn/).
     - title: RBM students
       content: >-
         Please apply directly through the [HKUST(GZ) Online Admission System](https://pgoas.hkust-gz.edu.cn/). After receiving an offer, you are welcome to contact me to discuss research fit; joining the group as an RA before making a final decision is encouraged. Please read the [Guidelines & Expectations](/files/MPhil_Guideline.pdf).

--- a/_data/students.yml
+++ b/_data/students.yml
@@ -44,6 +44,10 @@ alumni:
       degree: Ph.D.
       year: 2026
       destination: Ant Group (Talent Plan)
+    - name: Jindong Han
+      degree: Ph.D.
+      year: 2025
+      destination: Professor, Shandong University
     - name: Ruiqian Han
       degree: M.Phil.
       year: 2026
@@ -56,10 +60,6 @@ alumni:
       degree: M.Phil.
       year: 2026
       destination: Ph.D. student, Nanyang Technological University
-    - name: Jindong Han
-      degree: Ph.D.
-      year: 2025
-      destination: Professor, Shandong University
     - name: Zhao Xu
       degree: M.Phil.
       year: 2025
@@ -85,6 +85,10 @@ alumni:
       year: 2022
       destination: NIO Inc.
   assistants:
+    - name: Zhe Zhao
+      role: Visiting Student
+      background: Ph.D., USTC
+      destination: Postdoc, Stanford University
     - name: Xiaolong Jin
       role: Research Assistant
       background: Undergraduate, USTC

--- a/scripts/validate_content.rb
+++ b/scripts/validate_content.rb
@@ -143,8 +143,11 @@ assistant_alumni = Array(alumni["assistants"])
 student_alumni.each_with_index do |person, index|
   require_fields(person, %w[name degree year destination], "students.alumni.students[#{index}]", errors)
 end
-years = student_alumni.map { |person| person["year"].to_i }
-errors << "students.alumni.students: not ordered by year" unless years == years.sort.reverse
+degree_rank = { "Ph.D." => 0, "M.Phil." => 1 }
+expected_student_order = student_alumni.sort_by do |person|
+  [degree_rank.fetch(person["degree"], degree_rank.size), -person["year"].to_i]
+end
+errors << "students.alumni.students: expected Ph.D. alumni first, then M.Phil. alumni, with each group ordered by year" unless student_alumni == expected_student_order
 assistant_alumni.each_with_index do |person, index|
   require_fields(person, %w[name role background], "students.alumni.assistants[#{index}]", errors)
 end


### PR DESCRIPTION
## Summary

- advertise 1–2 postdoctoral and 3–4 Ph.D. openings for the Spring/Fall 2027 intake
- give separate application-material guidance for postdoctoral and Ph.D. candidates and link the formal admissions system
- place Ph.D. alumni before M.Phil. alumni, with each group ordered by graduation year
- add Zhe Zhao as a former visiting student who continued to a postdoc at Stanford University
- update structured-content validation and the maintenance guide for the new alumni ordering rule

## Validation

- production Jekyll build
- structured-content validation
- publication-data validation
- generated-site metadata, link, asset, and rendered-count validation
- rendered text and alumni ordering inspection
