### PR TITLE
Trim PhD application guidance

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -21,7 +21,7 @@ join:
   opportunities:
     - title: Postdoc and PhD students
       content: >-
-        We expect to have 1–2 postdoctoral openings and 3–4 Ph.D. openings for the Spring/Fall 2027 intake. Candidates whose interests align with our research are encouraged to apply. Postdoctoral applicants should email a CV, research statement, representative work, and preferred start date to [liuh@ust.hk](mailto:liuh@ust.hk). Prospective Ph.D. students should email a CV, transcripts, representative work, and intended intake; formal applications should also be submitted through the [HKUST(GZ) Online Admission System](https://pgoas.hkust-gz.edu.cn/).
+        We expect to have 1–2 postdoctoral openings and 3–4 Ph.D. openings for the Spring/Fall 2027 intake. Candidates whose interests align with our research are encouraged to apply. Postdoctoral applicants should email a CV, research statement, representative work, and preferred start date to [liuh@ust.hk](mailto:liuh@ust.hk). Prospective Ph.D. students should email a CV, transcripts, representative work, and intended intake.
     - title: RBM students
       content: >-
         Please apply directly through the [HKUST(GZ) Online Admission System](https://pgoas.hkust-gz.edu.cn/). After receiving an offer, you are welcome to contact me to discuss research fit; joining the group as an RA before making a final decision is encouraged. Please read the [Guidelines & Expectations](/files/MPhil_Guideline.pdf).


### PR DESCRIPTION
## Summary

- remove the formal HKUST(GZ) application-system sentence from the Postdoc and PhD students card
- retain the 2027 opening numbers and the requested application materials
- leave the RBM students admission-system guidance unchanged

## Validation

- structured-content validation
- production Jekyll build
- generated-site metadata, link, asset, and rendered-count validation
