### PR TITLE
Correct Hao Wang destination

### DIFF
--- a/_data/students.yml
+++ b/_data/students.yml
@@ -55,7 +55,7 @@ alumni:
     - name: Hao Wang
       degree: M.Phil.
       year: 2026
-      destination: City University of Hong Kong
+      destination: Ph.D. student, City University of Hong Kong
     - name: Yuxuan Fan
       degree: M.Phil.
       year: 2026


### PR DESCRIPTION
## What changed

- updated Hao Wang's alumni destination to `Ph.D. student, City University of Hong Kong`

## Impact

The Students page now includes both the destination institution and position.

## Validation

- structured-content validation
- production Jekyll build
- generated-site validation
- rendered Students-page content check
